### PR TITLE
Add kafka consumer metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,173 @@
+package blue_green_kafka
+
+import (
+	"sync"
+)
+
+type PartitionedInt64Metric struct {
+	values map[int]int64
+}
+
+func (pm *PartitionedInt64Metric) set(partition int, value int64) {
+	pm.values[partition] = value
+}
+
+func (pm *PartitionedInt64Metric) inc(partition int) {
+	pm.values[partition]++
+}
+
+func (pm *PartitionedInt64Metric) drop() {
+	pm.values = make(map[int]int64, len(pm.values))
+}
+
+func (pm *PartitionedInt64Metric) copy() *PartitionedInt64Metric {
+	c := make(map[int]int64, len(pm.values))
+	for k, v := range pm.values {
+		c[k] = v
+	}
+	return &PartitionedInt64Metric{values: c}
+}
+
+func (pm *PartitionedInt64Metric) GetByPartitions() map[int]int64 {
+	return pm.values
+}
+
+func newPartitionedInt64Metric() *PartitionedInt64Metric {
+	return &PartitionedInt64Metric{
+		values: make(map[int]int64),
+	}
+}
+
+// Metrics contains BG consumer metrics update on last message poll
+// Values split by partitions and contains data only from partitions assigned to this consumer
+type Metrics struct {
+	// Topic is a name of consuming topic
+	Topic string
+
+	// HighWatermark is the latest offset available on the broker for this partition
+	HighWatermark *PartitionedInt64Metric
+	// LastPollOffset the most recently read message offset on the partition
+	LastPollOffset *PartitionedInt64Metric
+	// CommitOffset is the commited message offset
+	CommitOffset *PartitionedInt64Metric
+	// Lag is a difference between HighWatermark-1 and CommitOffset - number of unconsumed messages
+	Lag *PartitionedInt64Metric
+
+	// ConsumedMessageCount is a number of messages consumed for this partition (succeed message polls)
+	ConsumedMessageCount *PartitionedInt64Metric
+	// AcceptedMessageCount is a number of messages accepted by blue-green state filter
+	AcceptedMessageCount *PartitionedInt64Metric
+	// FilteredMessageCount is a number of messages filtered by blue-green state filter
+	FilteredMessageCount *PartitionedInt64Metric
+	// CommitsCount is a number of succeed offset commits
+	CommitCount *PartitionedInt64Metric
+
+	mu sync.RWMutex
+}
+
+type pollMetricsUpdate struct {
+	partition     int
+	highWaterMark int64
+	currentOffset int64
+	isAccepted    bool
+}
+
+type commitMetricsUpdate struct {
+	partition    int
+	commitOffset int64
+}
+
+func NewConsumerMetrics(topic string) *Metrics {
+	return &Metrics{
+		Topic:                topic,
+		HighWatermark:        newPartitionedInt64Metric(),
+		LastPollOffset:       newPartitionedInt64Metric(),
+		CommitOffset:         newPartitionedInt64Metric(),
+		Lag:                  newPartitionedInt64Metric(),
+		ConsumedMessageCount: newPartitionedInt64Metric(),
+		AcceptedMessageCount: newPartitionedInt64Metric(),
+		FilteredMessageCount: newPartitionedInt64Metric(),
+		CommitCount:          newPartitionedInt64Metric(),
+		mu:                   sync.RWMutex{},
+	}
+}
+
+func (m *Metrics) updateMetricsOnPoll(update *pollMetricsUpdate) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	partition := update.partition
+
+	m.ConsumedMessageCount.inc(partition)
+	if update.isAccepted {
+		m.AcceptedMessageCount.inc(partition)
+	} else {
+		m.FilteredMessageCount.inc(partition)
+	}
+
+	lastHighWaterMark, exists := m.HighWatermark.values[partition]
+	if exists && lastHighWaterMark > update.highWaterMark {
+		// skip message with lower high watermark as it can be old message processed with invalid order
+		return
+	}
+	m.HighWatermark.set(partition, update.highWaterMark)
+	m.LastPollOffset.set(partition, update.currentOffset)
+
+	commitOffset, exists := m.CommitOffset.values[partition]
+	if !exists {
+		// offset of the first message is 0. To clear difference between 2 cases:
+		// - first commit: commitOffset = 0
+		// - no commit: commitOffset not exists but default value is 0
+		// Must consider default value as -1
+		commitOffset = -1
+	}
+	m.Lag.set(partition, update.highWaterMark-1-commitOffset)
+}
+
+func (m *Metrics) updateMetricsOnCommit(update *commitMetricsUpdate) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	partition := update.partition
+
+	m.CommitCount.inc(partition)
+	m.CommitOffset.set(partition, update.commitOffset)
+
+	hwm, exists := m.HighWatermark.values[partition]
+	if !exists {
+		return
+	}
+
+	m.Lag.set(partition, hwm-1-update.commitOffset)
+}
+
+func (m *Metrics) snapshot() Metrics {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return Metrics{
+		Topic:                m.Topic,
+		HighWatermark:        m.HighWatermark.copy(),
+		LastPollOffset:       m.LastPollOffset.copy(),
+		CommitOffset:         m.CommitOffset.copy(),
+		Lag:                  m.Lag.copy(),
+		ConsumedMessageCount: m.ConsumedMessageCount.copy(),
+		AcceptedMessageCount: m.AcceptedMessageCount.copy(),
+		FilteredMessageCount: m.FilteredMessageCount.copy(),
+		CommitCount:          m.CommitCount.copy(),
+	}
+}
+
+func (m *Metrics) clean() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.HighWatermark.drop()
+	m.LastPollOffset.drop()
+	m.CommitOffset.drop()
+	m.Lag.drop()
+	m.ConsumedMessageCount.drop()
+	m.AcceptedMessageCount.drop()
+	m.FilteredMessageCount.drop()
+	m.CommitCount.drop()
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,346 @@
+package blue_green_kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetrics_updateMetricsOnPoll(t *testing.T) {
+	const (
+		topic = "test-topic"
+
+		partitionIdx1 = 1
+		partitionIdx2 = 2
+	)
+
+	tests := []struct {
+		name            string
+		update          []*pollMetricsUpdate
+		commitOffset    *PartitionedInt64Metric
+		expectedMetrics *Metrics
+	}{
+		{
+			name: "should update high watermark, last poll offset and poll counters",
+			update: []*pollMetricsUpdate{
+				{
+					partition:     partitionIdx1,
+					highWaterMark: 5,
+					currentOffset: 1,
+					isAccepted:    false,
+				},
+				{
+					partition:     partitionIdx1,
+					highWaterMark: 6,
+					currentOffset: 3,
+					isAccepted:    true,
+				},
+				{
+					partition:     partitionIdx2,
+					highWaterMark: 100,
+					currentOffset: 99,
+					isAccepted:    true,
+				},
+				{
+					partition:     partitionIdx1,
+					highWaterMark: 100,
+					currentOffset: 19,
+					isAccepted:    true,
+				},
+			},
+			commitOffset: &PartitionedInt64Metric{
+				values: map[int]int64{
+					// commit 20 msgs for 1'st partition and 100 msgs for 2'nd partition
+					partitionIdx1: 19,
+					partitionIdx2: 99,
+				},
+			},
+			expectedMetrics: &Metrics{
+				Topic: topic,
+				HighWatermark: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 100,
+						partitionIdx2: 100,
+					},
+				},
+				LastPollOffset: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 19,
+						partitionIdx2: 99,
+					},
+				},
+				Lag: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 80,
+						partitionIdx2: 0,
+					},
+				},
+				ConsumedMessageCount: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 3,
+						partitionIdx2: 1,
+					},
+				},
+				AcceptedMessageCount: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 2,
+						partitionIdx2: 1,
+					},
+				},
+				FilteredMessageCount: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "should update only counters for outdated offset data",
+			update: []*pollMetricsUpdate{
+				{
+					partition:     partitionIdx1,
+					highWaterMark: 5,
+					currentOffset: 2,
+					isAccepted:    true,
+				},
+				{
+					partition:     partitionIdx1,
+					highWaterMark: 4,
+					currentOffset: 1,
+					isAccepted:    false,
+				},
+			},
+			expectedMetrics: &Metrics{
+				Topic: topic,
+				HighWatermark: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 5,
+					},
+				},
+				LastPollOffset: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 2,
+					},
+				},
+				Lag: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 5,
+					},
+				},
+				ConsumedMessageCount: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 2,
+					},
+				},
+				AcceptedMessageCount: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 1,
+					},
+				},
+				FilteredMessageCount: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 1,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewConsumerMetrics(topic)
+			if tt.commitOffset != nil {
+				m.CommitOffset = tt.commitOffset
+			}
+			for _, update := range tt.update {
+				m.updateMetricsOnPoll(update)
+			}
+			assert.Equal(t, tt.expectedMetrics.Topic, m.Topic, "unexpected topic name")
+			assert.Equal(t, tt.expectedMetrics.HighWatermark, m.HighWatermark, "unexpected high water mark value")
+			assert.Equal(t, tt.expectedMetrics.LastPollOffset, m.LastPollOffset, "unexpected current offset value")
+			assert.Equal(t, tt.expectedMetrics.Lag, m.Lag, "unexpected lag value")
+			assert.Equal(t, tt.expectedMetrics.ConsumedMessageCount, m.ConsumedMessageCount, "unexpected consumed message count")
+			assert.Equal(t, tt.expectedMetrics.AcceptedMessageCount, m.AcceptedMessageCount, "unexpected accepted message count")
+			assert.Equal(t, tt.expectedMetrics.FilteredMessageCount, m.FilteredMessageCount, "unexpected filtered message count")
+		})
+	}
+}
+
+func TestMetrics_updateMetricsOnCommit(t *testing.T) {
+	const (
+		topic = "test-topic"
+
+		partitionIdx1 = 1
+		partitionIdx2 = 2
+	)
+
+	tests := []struct {
+		name            string
+		update          *commitMetricsUpdate
+		highWaterMark   *PartitionedInt64Metric
+		expectedMetrics *Metrics
+	}{
+		{
+			name: "should increase counter, update lag and commit offset for existing high watermark",
+			update: &commitMetricsUpdate{
+				partition:    partitionIdx1,
+				commitOffset: 100,
+			},
+			highWaterMark: &PartitionedInt64Metric{
+				values: map[int]int64{
+					partitionIdx1: 111,
+					partitionIdx2: 2,
+				},
+			},
+			expectedMetrics: &Metrics{
+				CommitOffset: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 100,
+					},
+				},
+				Lag: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 10,
+					},
+				},
+				CommitCount: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "should increase counter and update offset only (without lag) when no high watermark info",
+			update: &commitMetricsUpdate{
+				partition:    partitionIdx1,
+				commitOffset: 100,
+			},
+			highWaterMark: &PartitionedInt64Metric{
+				values: map[int]int64{
+					partitionIdx2: 2,
+				},
+			},
+			expectedMetrics: &Metrics{
+				CommitOffset: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 100,
+					},
+				},
+				Lag: newPartitionedInt64Metric(),
+				CommitCount: &PartitionedInt64Metric{
+					values: map[int]int64{
+						partitionIdx1: 1,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewConsumerMetrics(topic)
+			if tt.highWaterMark != nil {
+				m.HighWatermark = tt.highWaterMark
+			}
+			m.updateMetricsOnCommit(tt.update)
+			assert.Equal(t, tt.expectedMetrics.Lag, m.Lag, "unexpected lag value")
+			assert.Equal(t, tt.expectedMetrics.CommitOffset, m.CommitOffset, "unexpected commit offset value")
+			assert.Equal(t, tt.expectedMetrics.CommitCount, m.CommitCount, "unexpected commit count")
+		})
+	}
+}
+
+func TestMetrics_snapshot(t *testing.T) {
+	t.Run("should create a copy of metrics", func(t *testing.T) {
+		m := &Metrics{
+			Topic: "topic",
+			HighWatermark: &PartitionedInt64Metric{
+				values: map[int]int64{
+					1: 5,
+				},
+			},
+			LastPollOffset: &PartitionedInt64Metric{
+				values: map[int]int64{
+					1: 2,
+				},
+			},
+			CommitOffset: &PartitionedInt64Metric{
+				values: map[int]int64{
+					1: 1,
+				},
+			},
+			Lag: &PartitionedInt64Metric{
+				values: map[int]int64{
+					1: 3,
+				},
+			},
+			ConsumedMessageCount: &PartitionedInt64Metric{
+				values: map[int]int64{
+					1: 2,
+				},
+			},
+			AcceptedMessageCount: &PartitionedInt64Metric{
+				values: map[int]int64{
+					1: 1,
+				},
+			},
+			FilteredMessageCount: &PartitionedInt64Metric{
+				values: map[int]int64{
+					1: 1,
+				},
+			},
+			CommitCount: &PartitionedInt64Metric{
+				values: map[int]int64{
+					1: 1,
+				},
+			},
+		}
+		snapshot := m.snapshot()
+		assert.Equal(t, snapshot.Topic, m.Topic, "unexpected topic name")
+		assert.Equal(t, snapshot.HighWatermark, m.HighWatermark, "unexpected high water mark value")
+		assert.Equal(t, snapshot.LastPollOffset, m.LastPollOffset, "unexpected current offset value")
+		assert.Equal(t, snapshot.CommitOffset, m.CommitOffset, "unexpected commit offset value")
+		assert.Equal(t, snapshot.Lag, m.Lag, "unexpected lag value")
+		assert.Equal(t, snapshot.ConsumedMessageCount, m.ConsumedMessageCount, "unexpected consumed message count")
+		assert.Equal(t, snapshot.AcceptedMessageCount, m.AcceptedMessageCount, "unexpected accepted message count")
+		assert.Equal(t, snapshot.FilteredMessageCount, m.FilteredMessageCount, "unexpected filtered message count")
+		assert.Equal(t, snapshot.CommitCount, m.CommitCount, "unexpected commit count")
+	})
+}
+
+func TestMetrics_clean(t *testing.T) {
+	t.Run("should clean read metrics data", func(t *testing.T) {
+		testPartitionedMetric := &PartitionedInt64Metric{
+			values: map[int]int64{
+				1: 1,
+				2: 0,
+				3: 100,
+			},
+		}
+		droppedPartitionMetric := &PartitionedInt64Metric{
+			values: map[int]int64{},
+		}
+		topic := "test-topic"
+		m := &Metrics{
+			Topic:                topic,
+			HighWatermark:        testPartitionedMetric,
+			LastPollOffset:       testPartitionedMetric,
+			CommitOffset:         testPartitionedMetric,
+			Lag:                  testPartitionedMetric,
+			ConsumedMessageCount: testPartitionedMetric,
+			AcceptedMessageCount: testPartitionedMetric,
+			FilteredMessageCount: testPartitionedMetric,
+			CommitCount:          testPartitionedMetric,
+		}
+
+		m.clean()
+		assert.Equal(t, topic, m.Topic, "unexpected topic name")
+		assert.Equal(t, droppedPartitionMetric, m.HighWatermark, "unexpected high water mark value")
+		assert.Equal(t, droppedPartitionMetric, m.LastPollOffset, "unexpected current offset value")
+		assert.Equal(t, droppedPartitionMetric, m.CommitOffset, "unexpected commit offset value")
+		assert.Equal(t, droppedPartitionMetric, m.Lag, "unexpected lag value")
+		assert.Equal(t, droppedPartitionMetric, m.ConsumedMessageCount, "unexpected consumed message count")
+		assert.Equal(t, droppedPartitionMetric, m.AcceptedMessageCount, "unexpected accepted message count")
+		assert.Equal(t, droppedPartitionMetric, m.FilteredMessageCount, "unexpected filtered message count")
+		assert.Equal(t, droppedPartitionMetric, m.CommitCount, "unexpected commit count")
+	})
+}

--- a/native.go
+++ b/native.go
@@ -10,6 +10,7 @@ import (
 type Message interface {
 	Topic() string
 	Offset() int64
+	HighWaterMark() int64
 	Headers() []Header
 	Key() []byte
 	Value() []byte

--- a/native_mock.go
+++ b/native_mock.go
@@ -49,6 +49,20 @@ func (mr *MockMessageMockRecorder) Headers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Headers", reflect.TypeOf((*MockMessage)(nil).Headers))
 }
 
+// HighWaterMark mocks base method.
+func (m *MockMessage) HighWaterMark() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HighWaterMark")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// HighWaterMark indicates an expected call of HighWaterMark.
+func (mr *MockMessageMockRecorder) HighWaterMark() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HighWaterMark", reflect.TypeOf((*MockMessage)(nil).HighWaterMark))
+}
+
 // Key mocks base method.
 func (m *MockMessage) Key() []byte {
 	m.ctrl.T.Helper()

--- a/test/testcontainers.go
+++ b/test/testcontainers.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/docker/go-connections/nat"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/kafka"
-	"net/url"
 	"os"
 	"testing"
 )
@@ -31,18 +29,10 @@ func setTestDocker(t *testing.T) {
 func StartContainers(t *testing.T) ([]string, error) {
 	ctx := context.Background()
 	setTestDocker(t)
-	kafkaHost := "127.0.0.1"
-	if dockerHost := os.Getenv("DOCKER_HOST"); dockerHost != "" {
-		dockerUrl, err := url.Parse(dockerHost)
-		if err != nil {
-			return nil, err
-		}
-		kafkaHost = dockerUrl.Hostname()
-		t.Logf("found DOCKER_HOST='%s'. Setting kafkaHost='%s'", dockerHost, kafkaHost)
-	}
-	kafkaContainer, err := kafka.RunContainer(ctx,
+
+	kafkaContainer, err := kafka.Run(ctx,
+		"confluentinc/confluent-local:7.5.0",
 		kafka.WithClusterID("test-cluster"),
-		testcontainers.WithImage("confluentinc/confluent-local:7.5.0"),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Changelist:
- Added `Metrics` struct which provides kafka consumer metrics with division by consumer group and by partition in each consumer group.
- List of metrics:
  - `HighWatermark` - the latest offset available on the broker for this partition
  - `LastPollOffset` - the most recently read message offset
  - `CommitOffset` - last commit offset
  - `Lag` is a difference between **HighWatermark - 1** (because the high watermark is the offset of the latest message in the topic/partition available for consumption + 1) and **CommitOffset** - number of unconsumed messages
  - `ConsumedMessageCount` is a number of messages consumed for this partition since
  - `AcceptedMessageCount` is a number of messages accepted by blue-green state filter
  - `FilteredMessageCount` is a number of messages filtered by blue-green state filter
  - `CommitCount` is a number of succeeded commits
- _Counters limitation_: as metrics stores in go runtime counters are reset on consumer restart. It may cause unexpected metric drop in metrics storage system when proving value as-is. 
- Extended `native` message interface to provide actual information about partition highwatermark on message read