### PR TITLE
fix: offset corrector silently rewrites existing consumer groups' offsets on every start

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -148,6 +148,10 @@ func (c *BgConsumer) Commit(ctx context.Context, marker *CommitMarker) error {
 	return nil
 }
 
+// Poll returns the next record; a record is never redelivered within a session, even if it
+// is not committed (see Consumer.ReadMessage). On a processing failure, retry the returned
+// record in place instead of calling Poll again — once a later offset on the same partition
+// commits, an uncommitted earlier record is permanently skipped.
 func (c *BgConsumer) Poll(ctx context.Context, readTimeout time.Duration) (*Record, error) {
 	c.pollMux.Lock()
 	defer c.pollMux.Unlock()

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -416,13 +416,22 @@ func (m *mockAdmin) PartitionsFor(ctx context.Context, topics ...string) ([]Part
 	return []PartitionInfo{{Topic: "test-topic", Partition: 0}}, nil
 }
 func (m *mockAdmin) BeginningOffsets(ctx context.Context, topicPartitions []TopicPartition) (map[TopicPartition]int64, error) {
-	return nil, nil
+	return offsetsFor(topicPartitions, 0), nil
 }
 func (m *mockAdmin) EndOffsets(ctx context.Context, topicPartitions []TopicPartition) (map[TopicPartition]int64, error) {
-	return nil, nil
+	return offsetsFor(topicPartitions, 0), nil
 }
 func (m *mockAdmin) OffsetsForTimes(ctx context.Context, times map[TopicPartition]time.Time) (map[TopicPartition]*OffsetAndTimestamp, error) {
 	return nil, nil
+}
+
+// offsetsFor mimics a real broker response: an entry for every requested partition.
+func offsetsFor(topicPartitions []TopicPartition, offset int64) map[TopicPartition]int64 {
+	result := make(map[TopicPartition]int64, len(topicPartitions))
+	for _, tp := range topicPartitions {
+		result[tp] = offset
+	}
+	return result
 }
 
 func TestBgConsumer_Stats(t *testing.T) {

--- a/corrector.go
+++ b/corrector.go
@@ -19,9 +19,18 @@ type offsetCorrector struct {
 }
 
 func (oc *offsetCorrector) align(ctx context.Context, current GroupId) error {
-	// todo remove oldFormatBgVersionsExist() check when oldFormats versioned groups are deleted for good
-	if oc.indexer.exists(current) && (!oc.indexer.bg1VersionsExist() || oc.indexer.bg1VersionsMigrated()) {
+	topicPartitions, err := oc.topicPartitions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get partitions: %w", err)
+	}
+	// A group that already has committed offsets for every partition of this topic must never
+	// have those offsets altered here, regardless of BG1 migration state - only the (separate)
+	// migration-marker bookkeeping below still needs to run in that case.
+	if oc.indexer.exists(current, topicPartitions) {
 		logger.InfoC(ctx, "Skip group id offsets corrections for: '%s'", current.String())
+		if oc.indexer.bg1VersionsExist() && !oc.indexer.bg1VersionsMigrated() {
+			return oc.indexer.createMigrationDoneFromBg1MarkerGroup(ctx)
+		}
 		return nil
 	}
 	prevIds := oc.indexer.findPreviousStateOffset(ctx, current)
@@ -49,7 +58,7 @@ func (oc *offsetCorrector) align(ctx context.Context, current GroupId) error {
 				logger.WarnC(ctx, "No proposed offset resolved for state '%v'. Using default: '%v'", vg.State, strategy)
 			}
 		}
-		proposedOffset, err = oc.install(ctx, strategy)
+		proposedOffset, err = oc.install(ctx, strategy, topicPartitions)
 		if err != nil {
 			return fmt.Errorf("failed to install offsets: %w", err)
 		}
@@ -65,21 +74,29 @@ func (oc *offsetCorrector) align(ctx context.Context, current GroupId) error {
 	return nil
 }
 
-func (oc *offsetCorrector) install(ctx context.Context, strategy OffsetSetupStrategy) (map[TopicPartition]OffsetAndMetadata, error) {
-	logger.InfoC(ctx, "Installing by strategy: %+v", strategy)
-	var topicPartitions []TopicPartition
+// topicPartitions fetches the current set of partitions for this corrector's topic, used both
+// to decide whether a group already has complete offsets (see exists()) and, if not, as the
+// partition set to install offsets for.
+func (oc *offsetCorrector) topicPartitions(ctx context.Context) ([]TopicPartition, error) {
 	partitions, err := oc.admin.PartitionsFor(ctx, oc.topic)
-	logger.InfoC(ctx, "topic: '%s' partitions=%+v", oc.topic, partitions)
 	if err != nil {
 		return nil, err
 	}
+	logger.InfoC(ctx, "topic: '%s' partitions=%+v", oc.topic, partitions)
+	topicPartitions := make([]TopicPartition, 0, len(partitions))
 	for _, pi := range partitions {
 		topicPartitions = append(topicPartitions, TopicPartition{
 			Partition: pi.Partition,
 			Topic:     pi.Topic,
 		})
 	}
+	return topicPartitions, nil
+}
+
+func (oc *offsetCorrector) install(ctx context.Context, strategy OffsetSetupStrategy, topicPartitions []TopicPartition) (map[TopicPartition]OffsetAndMetadata, error) {
+	logger.InfoC(ctx, "Installing by strategy: %+v", strategy)
 	var offsets map[TopicPartition]int64
+	var err error
 	if strategy == StrategyEarliest {
 		logger.InfoC(ctx, "Calculating BeginningOffsets")
 		offsets, err = oc.admin.BeginningOffsets(ctx, topicPartitions)
@@ -87,6 +104,11 @@ func (oc *offsetCorrector) install(ctx context.Context, strategy OffsetSetupStra
 			return nil, fmt.Errorf("failed to calculate BeginningOffsets: %w", err)
 		}
 		logger.InfoC(ctx, "Calculated BeginningOffsets=%+v", offsets)
+		for _, tp := range topicPartitions {
+			if _, ok := offsets[tp]; !ok {
+				return nil, fmt.Errorf("no BeginningOffsets result for partition %+v", tp)
+			}
+		}
 	} else if strategy == StrategyLatest {
 		logger.InfoC(ctx, "Calculating EndOffsets")
 		offsets, err = oc.admin.EndOffsets(ctx, topicPartitions)
@@ -94,6 +116,11 @@ func (oc *offsetCorrector) install(ctx context.Context, strategy OffsetSetupStra
 			return nil, fmt.Errorf("failed to calculate EndOffsets: %w", err)
 		}
 		logger.InfoC(ctx, "Calculated EndOffsets=%+v", offsets)
+		for _, tp := range topicPartitions {
+			if _, ok := offsets[tp]; !ok {
+				return nil, fmt.Errorf("no EndOffsets result for partition %+v", tp)
+			}
+		}
 	} else {
 		query := map[TopicPartition]time.Time{}
 		for _, e := range topicPartitions {
@@ -116,9 +143,14 @@ func (oc *offsetCorrector) install(ctx context.Context, strategy OffsetSetupStra
 		}
 		logger.InfoC(ctx, "Calculated EndOffsets=%+v", fallback)
 		offsets = map[TopicPartition]int64{}
-		for topicPart, offsetTime := range found {
-			if offsetTime == nil {
-				offsets[topicPart] = fallback[topicPart]
+		for _, topicPart := range topicPartitions {
+			offsetTime, ok := found[topicPart]
+			if !ok || offsetTime == nil {
+				fallbackOffset, ok := fallback[topicPart]
+				if !ok {
+					return nil, fmt.Errorf("no EndOffsets fallback available for partition %+v", topicPart)
+				}
+				offsets[topicPart] = fallbackOffset
 			} else {
 				offsets[topicPart] = offsetTime.Offset
 			}

--- a/corrector.go
+++ b/corrector.go
@@ -23,10 +23,29 @@ func (oc *offsetCorrector) align(ctx context.Context, current GroupId) error {
 	if err != nil {
 		return fmt.Errorf("failed to get partitions: %w", err)
 	}
-	// An existing group's offsets are never altered here, regardless of BG1 state; only
-	// migration-marker bookkeeping below still runs for it.
-	if oc.indexer.exists(current, topicPartitions) {
-		logger.InfoC(ctx, "Skip group id offsets corrections for: '%s'", current.String())
+	// An existing group's committed offsets are never altered here, regardless of BG1 state.
+	// Only partitions without a committed offset (e.g. added to the topic after the group
+	// last committed) get offsets installed; migration-marker bookkeeping still runs.
+	if committed := oc.indexer.committedOffsets(current); len(committed) > 0 {
+		var missing []TopicPartition
+		for _, tp := range topicPartitions {
+			if _, ok := committed[tp]; !ok {
+				missing = append(missing, tp)
+			}
+		}
+		if len(missing) == 0 {
+			logger.InfoC(ctx, "Skip group id offsets corrections for: '%s'", current.String())
+		} else {
+			logger.InfoC(ctx, "Group '%s' has no committed offsets for partitions %+v, installing offsets for them only", current.String(), missing)
+			proposedOffset, err := oc.install(ctx, oc.setupStrategy(ctx, current), missing)
+			if err != nil {
+				return fmt.Errorf("failed to install offsets: %w", err)
+			}
+			logger.InfoC(ctx, "Alter group %s offset to %+v", current, proposedOffset)
+			if err = oc.admin.AlterConsumerGroupOffsets(ctx, current, proposedOffset); err != nil {
+				return fmt.Errorf("failed to alter consumer group: %w", err)
+			}
+		}
 		if oc.indexer.bg1VersionsExist() && !oc.indexer.bg1VersionsMigrated() {
 			return oc.indexer.createMigrationDoneFromBg1MarkerGroup(ctx)
 		}
@@ -43,21 +62,7 @@ func (oc *offsetCorrector) align(ctx context.Context, current GroupId) error {
 		return fmt.Errorf("failed to inherit offsets: %w", err)
 	}
 	if len(proposedOffset) == 0 {
-		var strategy OffsetSetupStrategy
-		if _, ok := current.(*PlainGroupId); ok {
-			strategy = oc.activeOffsetSetupStrategy
-		} else if vg, ok := current.(*VersionedGroupId); ok {
-			switch vg.State {
-			case bgMonitor.StateActive:
-				strategy = oc.activeOffsetSetupStrategy
-			case bgMonitor.StateCandidate:
-				strategy = oc.candidateOffsetSetupStrategy
-			default:
-				strategy = Rewind(5 * time.Minute)
-				logger.WarnC(ctx, "No proposed offset resolved for state '%v'. Using default: '%v'", vg.State, strategy)
-			}
-		}
-		proposedOffset, err = oc.install(ctx, strategy, topicPartitions)
+		proposedOffset, err = oc.install(ctx, oc.setupStrategy(ctx, current), topicPartitions)
 		if err != nil {
 			return fmt.Errorf("failed to install offsets: %w", err)
 		}
@@ -73,7 +78,26 @@ func (oc *offsetCorrector) align(ctx context.Context, current GroupId) error {
 	return nil
 }
 
-// topicPartitions fetches this corrector's topic partitions, used by both exists() and install().
+// setupStrategy picks the configured offset setup strategy for current's group kind and state.
+func (oc *offsetCorrector) setupStrategy(ctx context.Context, current GroupId) OffsetSetupStrategy {
+	var strategy OffsetSetupStrategy
+	if _, ok := current.(*PlainGroupId); ok {
+		strategy = oc.activeOffsetSetupStrategy
+	} else if vg, ok := current.(*VersionedGroupId); ok {
+		switch vg.State {
+		case bgMonitor.StateActive:
+			strategy = oc.activeOffsetSetupStrategy
+		case bgMonitor.StateCandidate:
+			strategy = oc.candidateOffsetSetupStrategy
+		default:
+			strategy = Rewind(5 * time.Minute)
+			logger.WarnC(ctx, "No proposed offset resolved for state '%v'. Using default: '%v'", vg.State, strategy)
+		}
+	}
+	return strategy
+}
+
+// topicPartitions fetches this corrector's topic partitions, used by align() and install().
 func (oc *offsetCorrector) topicPartitions(ctx context.Context) ([]TopicPartition, error) {
 	partitions, err := oc.admin.PartitionsFor(ctx, oc.topic)
 	if err != nil {

--- a/corrector.go
+++ b/corrector.go
@@ -23,9 +23,8 @@ func (oc *offsetCorrector) align(ctx context.Context, current GroupId) error {
 	if err != nil {
 		return fmt.Errorf("failed to get partitions: %w", err)
 	}
-	// A group that already has committed offsets for every partition of this topic must never
-	// have those offsets altered here, regardless of BG1 migration state - only the (separate)
-	// migration-marker bookkeeping below still needs to run in that case.
+	// An existing group's offsets are never altered here, regardless of BG1 state; only
+	// migration-marker bookkeeping below still runs for it.
 	if oc.indexer.exists(current, topicPartitions) {
 		logger.InfoC(ctx, "Skip group id offsets corrections for: '%s'", current.String())
 		if oc.indexer.bg1VersionsExist() && !oc.indexer.bg1VersionsMigrated() {
@@ -74,9 +73,7 @@ func (oc *offsetCorrector) align(ctx context.Context, current GroupId) error {
 	return nil
 }
 
-// topicPartitions fetches the current set of partitions for this corrector's topic, used both
-// to decide whether a group already has complete offsets (see exists()) and, if not, as the
-// partition set to install offsets for.
+// topicPartitions fetches this corrector's topic partitions, used by both exists() and install().
 func (oc *offsetCorrector) topicPartitions(ctx context.Context) ([]TopicPartition, error) {
 	partitions, err := oc.admin.PartitionsFor(ctx, oc.topic)
 	if err != nil {

--- a/corrector_test.go
+++ b/corrector_test.go
@@ -27,7 +27,7 @@ func Test_align_groupExists_noBg1(t *testing.T) {
 	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 
 	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
-	indexer.EXPECT().exists(plainGroup, topicPartitions).Return(true)
+	indexer.EXPECT().committedOffsets(plainGroup).Return(map[TopicPartition]OffsetAndMetadata{topicPartitions[0]: {Offset: 100}})
 	indexer.EXPECT().bg1VersionsExist().Return(false)
 	err := corrector.align(context.Background(), plainGroup)
 	assertions.NoError(err)
@@ -50,7 +50,7 @@ func Test_align_groupExists_Bg1Migrated(t *testing.T) {
 	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 
 	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
-	indexer.EXPECT().exists(plainGroup, topicPartitions).Return(true)
+	indexer.EXPECT().committedOffsets(plainGroup).Return(map[TopicPartition]OffsetAndMetadata{topicPartitions[0]: {Offset: 100}})
 	indexer.EXPECT().bg1VersionsExist().Return(true)
 	indexer.EXPECT().bg1VersionsMigrated().Return(true)
 
@@ -77,7 +77,7 @@ func Test_align_groupExists_Bg1NotMigrated(t *testing.T) {
 	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 
 	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
-	indexer.EXPECT().exists(plainGroup, topicPartitions).Return(true)
+	indexer.EXPECT().committedOffsets(plainGroup).Return(map[TopicPartition]OffsetAndMetadata{topicPartitions[0]: {Offset: 100}})
 	indexer.EXPECT().bg1VersionsExist().Return(true)
 	indexer.EXPECT().bg1VersionsMigrated().Return(false)
 	indexer.EXPECT().createMigrationDoneFromBg1MarkerGroup(gomock.Any()).Return(nil)
@@ -104,7 +104,7 @@ func Test_align_groupNotExists(t *testing.T) {
 	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 
 	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
-	indexer.EXPECT().exists(plainGroup, topicPartitions).Return(false)
+	indexer.EXPECT().committedOffsets(plainGroup).Return(nil)
 	indexer.EXPECT().findPreviousStateOffset(gomock.Any(), plainGroup).Return([]groupIdWithOffset{})
 	adapter.EXPECT().EndOffsets(gomock.Any(), topicPartitions).Return(map[TopicPartition]int64{{Partition: 0, Topic: "test-topic"}: 100}, nil)
 	adapter.EXPECT().AlterConsumerGroupOffsets(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -115,8 +115,8 @@ func Test_align_groupNotExists(t *testing.T) {
 }
 
 // A plain group with committed offsets on multiple partitions must survive a consumer
-// restart untouched (exists()/findPreviousStateOffset() used to compare GroupId by pointer
-// identity, so a freshly re-parsed GroupId was never recognized as already existing).
+// restart untouched (the indexer lookup and findPreviousStateOffset() used to compare GroupId
+// by pointer identity, so a freshly re-parsed GroupId was never recognized as already existing).
 func Test_align_existingPlainGroupWithMultiplePartitions_survivesRestart(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
@@ -153,6 +153,50 @@ func Test_align_existingPlainGroupWithMultiplePartitions_survivesRestart(t *test
 		{Partition: 0, Topic: "test-topic"}, {Partition: 1, Topic: "test-topic"},
 	}, nil)
 	// no OffsetsForTimes/EndOffsets/AlterConsumerGroupOffsets expectations: skip correction entirely
+	err = corrector.align(ctx, current)
+	assertions.NoError(err)
+}
+
+// When partitions are added to the topic after a group last committed, offsets are installed
+// for the new partitions only; the group's existing committed offsets stay untouched.
+func Test_align_existingGroupWithNewPartitions_installsOffsetsForNewPartitionsOnly(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	controller := gomock.NewController(t)
+	adapter := NewMockNativeAdminAdapter(controller)
+
+	groupName := "test-plain-group"
+	committedPartition := TopicPartition{Partition: 0, Topic: "test-topic"}
+	newPartition := TopicPartition{Partition: 1, Topic: "test-topic"}
+	adapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
+		{GroupId: groupName},
+	}, nil)
+	adapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), groupName).Return(
+		map[TopicPartition]OffsetAndMetadata{committedPartition: {Offset: 100}}, nil)
+
+	indexer, err := newOffsetIndexer(ctx, groupName, "test-topic", adapter)
+	assertions.NoError(err)
+
+	corrector := &offsetCorrector{
+		topic:                        "test-topic",
+		indexer:                      indexer,
+		inherit:                      EventualStrategy(),
+		admin:                        adapter,
+		activeOffsetSetupStrategy:    StrategyLatest,
+		candidateOffsetSetupStrategy: StrategyLatest,
+	}
+	current, err := ParseGroupId(groupName)
+	assertions.NoError(err)
+
+	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{
+		{Partition: 0, Topic: "test-topic"}, {Partition: 1, Topic: "test-topic"},
+	}, nil)
+	// install and alter cover the new partition only; the committed one is never queried or altered
+	adapter.EXPECT().EndOffsets(gomock.Any(), []TopicPartition{newPartition}).Return(
+		map[TopicPartition]int64{newPartition: 999}, nil)
+	adapter.EXPECT().AlterConsumerGroupOffsets(gomock.Any(), current,
+		map[TopicPartition]OffsetAndMetadata{newPartition: {Offset: 999}}).Return(nil)
+
 	err = corrector.align(ctx, current)
 	assertions.NoError(err)
 }

--- a/corrector_test.go
+++ b/corrector_test.go
@@ -58,11 +58,8 @@ func Test_align_groupExists_Bg1Migrated(t *testing.T) {
 	assertions.NoError(err)
 }
 
-// Regression test: a group that already exists must have its offsets left untouched even
-// when unmigrated BG1 groups are also present - only the (separate) migration-marker
-// bookkeeping should still run. Before the fix, this combination of conditions caused the
-// skip to be bypassed entirely, so an existing group's offsets were force-rewound via
-// install()/Rewind(5m) on every restart (see corrector.go's exists() check).
+// An existing group's offsets must stay untouched even with unmigrated BG1 groups present;
+// only migration-marker bookkeeping should run for it.
 func Test_align_groupExists_Bg1NotMigrated(t *testing.T) {
 	assertions := require.New(t)
 	controller := gomock.NewController(t)
@@ -85,8 +82,7 @@ func Test_align_groupExists_Bg1NotMigrated(t *testing.T) {
 	indexer.EXPECT().bg1VersionsMigrated().Return(false)
 	indexer.EXPECT().createMigrationDoneFromBg1MarkerGroup(gomock.Any()).Return(nil)
 
-	// No findPreviousStateOffset/EndOffsets/AlterConsumerGroupOffsets expectations are set:
-	// the existing group's offsets must never be touched, only the migration marker created.
+	// no findPreviousStateOffset/EndOffsets/AlterConsumerGroupOffsets expectations: offsets stay untouched
 	err := corrector.align(context.Background(), plainGroup)
 	assertions.NoError(err)
 }
@@ -118,22 +114,19 @@ func Test_align_groupNotExists(t *testing.T) {
 	assertions.NoError(err)
 }
 
-// Regression test for the production incident: a plain (non blue-green) group with
-// committed offsets on multiple partitions must survive a consumer restart untouched.
-// Before the fix, offsetsIndexerImpl.exists() and findPreviousStateOffset() compared
-// GroupId values by pointer identity, so a freshly re-parsed GroupId with the same name
-// as an already-committed group was never recognized as existing, fell through to the
-// install path, and had its offsets force-rewound via Rewind(5m).
+// A plain group with committed offsets on multiple partitions must survive a consumer
+// restart untouched (exists()/findPreviousStateOffset() used to compare GroupId by pointer
+// identity, so a freshly re-parsed GroupId was never recognized as already existing).
 func Test_align_existingPlainGroupWithMultiplePartitions_survivesRestart(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 	controller := gomock.NewController(t)
 	adapter := NewMockNativeAdminAdapter(controller)
 
-	groupName := "history-events-a4c9373f"
+	groupName := "test-plain-group-multi-partition"
 	committedOffsets := map[TopicPartition]OffsetAndMetadata{
-		{Partition: 0, Topic: "test-topic"}: {Offset: 6893},
-		{Partition: 1, Topic: "test-topic"}: {Offset: 23081},
+		{Partition: 0, Topic: "test-topic"}: {Offset: 100},
+		{Partition: 1, Topic: "test-topic"}: {Offset: 200},
 	}
 	adapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
 		{GroupId: groupName},
@@ -152,26 +145,20 @@ func Test_align_existingPlainGroupWithMultiplePartitions_survivesRestart(t *test
 		candidateOffsetSetupStrategy: Rewind(5 * time.Minute),
 	}
 
-	// current is a distinct GroupId instance from the one indexed above, exactly as
-	// happens on every real consumer restart (ParseGroupId / &PlainGroupId{} allocate fresh).
+	// current is a distinct GroupId instance from the one indexed above, as on every restart
 	current, err := ParseGroupId(groupName)
 	assertions.NoError(err)
 
 	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{
 		{Partition: 0, Topic: "test-topic"}, {Partition: 1, Topic: "test-topic"},
 	}, nil)
-	// No OffsetsForTimes/EndOffsets/AlterConsumerGroupOffsets expectations are set: the
-	// corrector must recognize the group already exists (with offsets for both partitions)
-	// and skip correction entirely.
+	// no OffsetsForTimes/EndOffsets/AlterConsumerGroupOffsets expectations: skip correction entirely
 	err = corrector.align(ctx, current)
 	assertions.NoError(err)
 }
 
-// Regression test for a residual force-rewind path: even after the group already exists, a
-// leftover unmigrated BG1 group (any stage other than active/migrated) used to bypass the
-// skip entirely and re-run install()/Rewind(5m) against the existing group's offsets. The
-// skip must now be unconditional on existence; only migration-marker creation depends on
-// BG1 state.
+// The skip must be unconditional on existence: a leftover BG1 group in a stage other than
+// active/migrated must not bypass it and force a rewind of an existing group's offsets.
 func Test_align_existingPlainGroupWithUnmigratedBg1Leftover_survivesRestart(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
@@ -182,8 +169,7 @@ func Test_align_existingPlainGroupWithUnmigratedBg1Leftover_survivesRestart(t *t
 	committedOffsets := map[TopicPartition]OffsetAndMetadata{
 		{Partition: 0, Topic: "test-topic"}: {Offset: 500},
 	}
-	// A leftover BG1 group with a non-active, non-migrated stage (e.g. "legacy"): present,
-	// but neither an active source for migration nor already marked as migrated.
+	// leftover BG1 group, stage neither active nor migrated
 	bg1LeftoverOffsets := map[TopicPartition]OffsetAndMetadata{
 		{Partition: 0, Topic: "test-topic"}: {Offset: 10},
 	}
@@ -209,10 +195,8 @@ func Test_align_existingPlainGroupWithUnmigratedBg1Leftover_survivesRestart(t *t
 	assertions.NoError(err)
 
 	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
-	// No AlterConsumerGroupOffsets expectation: bg1VersionsExist()=true but
-	// bg1VersionsMigrated()=false (no active-stage BG1 group to migrate from), so
-	// createMigrationDoneFromBg1MarkerGroup logs a warning and returns nil without altering
-	// anything - the existing group's own offsets must remain untouched.
+	// no AlterConsumerGroupOffsets expectation: no active-stage BG1 group, so
+	// createMigrationDoneFromBg1MarkerGroup warns and returns nil without altering anything
 	err = corrector.align(ctx, current)
 	assertions.NoError(err)
 }
@@ -248,8 +232,7 @@ func TestOffsetCorrector_Install_StrategyEarliest_MissingPartition(t *testing.T)
 
 	ctx := context.Background()
 	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}, {Partition: 1, Topic: "test-topic"}}
-	// BeginningOffsets omits partition 1 entirely (e.g. adapter request-construction bug) -
-	// the corrector must error rather than silently omitting that partition from the alter.
+	// BeginningOffsets omits partition 1 entirely; must error, not silently drop it
 	adapter.EXPECT().BeginningOffsets(ctx, topicPartitions).Return(map[TopicPartition]int64{
 		{Partition: 0, Topic: "test-topic"}: 100,
 	}, nil)
@@ -359,8 +342,7 @@ func TestOffsetCorrector_Install_StrategyRewind_PartitionMissingFromOffsetsForTi
 	ctx := context.Background()
 	topicPartition := TopicPartition{Partition: 0, Topic: "test-topic"}
 	topicPartitions := []TopicPartition{topicPartition}
-	// The partition is entirely absent from the OffsetsForTimes response (not just present
-	// with a nil value) - the corrector must still fall back to EndOffsets for it.
+	// partition absent from the response entirely, not just nil; must still fall back
 	expectedEndOffsets := map[TopicPartition]int64{topicPartition: 200}
 
 	adapter.EXPECT().OffsetsForTimes(gomock.Any(), gomock.Any()).Return(map[TopicPartition]*OffsetAndTimestamp{}, nil)
@@ -469,8 +451,7 @@ func TestOffsetCorrector_Install_StrategyRewind_MissingFallback(t *testing.T) {
 	expectedTimes := map[TopicPartition]*OffsetAndTimestamp{topicPartition: nil} // no record at/after the timestamp
 
 	adapter.EXPECT().OffsetsForTimes(gomock.Any(), gomock.Any()).Return(expectedTimes, nil)
-	// EndOffsets omits the partition entirely (e.g. adapter request-construction bug) -
-	// the corrector must error rather than silently committing offset 0.
+	// EndOffsets fallback also omits the partition; must error, not commit offset 0
 	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(map[TopicPartition]int64{}, nil)
 
 	result, err := corrector.install(ctx, Rewind(5*time.Minute), topicPartitions)

--- a/corrector_test.go
+++ b/corrector_test.go
@@ -24,8 +24,10 @@ func Test_align_groupExists_noBg1(t *testing.T) {
 		candidateOffsetSetupStrategy: StrategyLatest,
 	}
 	plainGroup := MustParseGroupId("test-plain-group")
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 
-	indexer.EXPECT().exists(plainGroup).Return(true)
+	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
+	indexer.EXPECT().exists(plainGroup, topicPartitions).Return(true)
 	indexer.EXPECT().bg1VersionsExist().Return(false)
 	err := corrector.align(context.Background(), plainGroup)
 	assertions.NoError(err)
@@ -45,8 +47,10 @@ func Test_align_groupExists_Bg1Migrated(t *testing.T) {
 		candidateOffsetSetupStrategy: StrategyLatest,
 	}
 	plainGroup := MustParseGroupId("test-plain-group")
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 
-	indexer.EXPECT().exists(plainGroup).Return(true)
+	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
+	indexer.EXPECT().exists(plainGroup, topicPartitions).Return(true)
 	indexer.EXPECT().bg1VersionsExist().Return(true)
 	indexer.EXPECT().bg1VersionsMigrated().Return(true)
 
@@ -54,6 +58,11 @@ func Test_align_groupExists_Bg1Migrated(t *testing.T) {
 	assertions.NoError(err)
 }
 
+// Regression test: a group that already exists must have its offsets left untouched even
+// when unmigrated BG1 groups are also present - only the (separate) migration-marker
+// bookkeeping should still run. Before the fix, this combination of conditions caused the
+// skip to be bypassed entirely, so an existing group's offsets were force-rewound via
+// install()/Rewind(5m) on every restart (see corrector.go's exists() check).
 func Test_align_groupExists_Bg1NotMigrated(t *testing.T) {
 	assertions := require.New(t)
 	controller := gomock.NewController(t)
@@ -68,16 +77,16 @@ func Test_align_groupExists_Bg1NotMigrated(t *testing.T) {
 		candidateOffsetSetupStrategy: StrategyLatest,
 	}
 	plainGroup := MustParseGroupId("test-plain-group")
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 
-	indexer.EXPECT().exists(plainGroup).Return(true)
-	indexer.EXPECT().findPreviousStateOffset(gomock.Any(), plainGroup).Return([]groupIdWithOffset{})
 	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
-	adapter.EXPECT().EndOffsets(gomock.Any(), []TopicPartition{{Partition: 0, Topic: "test-topic"}}).Return(map[TopicPartition]int64{{Partition: 0, Topic: "test-topic"}: 100}, nil)
-	adapter.EXPECT().AlterConsumerGroupOffsets(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	indexer.EXPECT().bg1VersionsExist().Return(true).AnyTimes()
-	indexer.EXPECT().bg1VersionsMigrated().Return(false).AnyTimes()
+	indexer.EXPECT().exists(plainGroup, topicPartitions).Return(true)
+	indexer.EXPECT().bg1VersionsExist().Return(true)
+	indexer.EXPECT().bg1VersionsMigrated().Return(false)
 	indexer.EXPECT().createMigrationDoneFromBg1MarkerGroup(gomock.Any()).Return(nil)
 
+	// No findPreviousStateOffset/EndOffsets/AlterConsumerGroupOffsets expectations are set:
+	// the existing group's offsets must never be touched, only the migration marker created.
 	err := corrector.align(context.Background(), plainGroup)
 	assertions.NoError(err)
 }
@@ -96,15 +105,115 @@ func Test_align_groupNotExists(t *testing.T) {
 		candidateOffsetSetupStrategy: StrategyLatest,
 	}
 	plainGroup := MustParseGroupId("test-plain-group")
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 
-	indexer.EXPECT().exists(plainGroup).Return(false)
-	indexer.EXPECT().findPreviousStateOffset(gomock.Any(), plainGroup).Return([]groupIdWithOffset{})
 	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
-	adapter.EXPECT().EndOffsets(gomock.Any(), []TopicPartition{{Partition: 0, Topic: "test-topic"}}).Return(map[TopicPartition]int64{{Partition: 0, Topic: "test-topic"}: 100}, nil)
+	indexer.EXPECT().exists(plainGroup, topicPartitions).Return(false)
+	indexer.EXPECT().findPreviousStateOffset(gomock.Any(), plainGroup).Return([]groupIdWithOffset{})
+	adapter.EXPECT().EndOffsets(gomock.Any(), topicPartitions).Return(map[TopicPartition]int64{{Partition: 0, Topic: "test-topic"}: 100}, nil)
 	adapter.EXPECT().AlterConsumerGroupOffsets(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	indexer.EXPECT().bg1VersionsExist().Return(false).AnyTimes()
 
 	err := corrector.align(context.Background(), plainGroup)
+	assertions.NoError(err)
+}
+
+// Regression test for the production incident: a plain (non blue-green) group with
+// committed offsets on multiple partitions must survive a consumer restart untouched.
+// Before the fix, offsetsIndexerImpl.exists() and findPreviousStateOffset() compared
+// GroupId values by pointer identity, so a freshly re-parsed GroupId with the same name
+// as an already-committed group was never recognized as existing, fell through to the
+// install path, and had its offsets force-rewound via Rewind(5m).
+func Test_align_existingPlainGroupWithMultiplePartitions_survivesRestart(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	controller := gomock.NewController(t)
+	adapter := NewMockNativeAdminAdapter(controller)
+
+	groupName := "history-events-a4c9373f"
+	committedOffsets := map[TopicPartition]OffsetAndMetadata{
+		{Partition: 0, Topic: "test-topic"}: {Offset: 6893},
+		{Partition: 1, Topic: "test-topic"}: {Offset: 23081},
+	}
+	adapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
+		{GroupId: groupName},
+	}, nil)
+	adapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), groupName).Return(committedOffsets, nil)
+
+	indexer, err := newOffsetIndexer(ctx, groupName, "test-topic", adapter)
+	assertions.NoError(err)
+
+	corrector := &offsetCorrector{
+		topic:                        "test-topic",
+		indexer:                      indexer,
+		inherit:                      EventualStrategy(),
+		admin:                        adapter,
+		activeOffsetSetupStrategy:    Rewind(5 * time.Minute),
+		candidateOffsetSetupStrategy: Rewind(5 * time.Minute),
+	}
+
+	// current is a distinct GroupId instance from the one indexed above, exactly as
+	// happens on every real consumer restart (ParseGroupId / &PlainGroupId{} allocate fresh).
+	current, err := ParseGroupId(groupName)
+	assertions.NoError(err)
+
+	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{
+		{Partition: 0, Topic: "test-topic"}, {Partition: 1, Topic: "test-topic"},
+	}, nil)
+	// No OffsetsForTimes/EndOffsets/AlterConsumerGroupOffsets expectations are set: the
+	// corrector must recognize the group already exists (with offsets for both partitions)
+	// and skip correction entirely.
+	err = corrector.align(ctx, current)
+	assertions.NoError(err)
+}
+
+// Regression test for a residual force-rewind path: even after the group already exists, a
+// leftover unmigrated BG1 group (any stage other than active/migrated) used to bypass the
+// skip entirely and re-run install()/Rewind(5m) against the existing group's offsets. The
+// skip must now be unconditional on existence; only migration-marker creation depends on
+// BG1 state.
+func Test_align_existingPlainGroupWithUnmigratedBg1Leftover_survivesRestart(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	controller := gomock.NewController(t)
+	adapter := NewMockNativeAdminAdapter(controller)
+
+	groupName := "orders"
+	committedOffsets := map[TopicPartition]OffsetAndMetadata{
+		{Partition: 0, Topic: "test-topic"}: {Offset: 500},
+	}
+	// A leftover BG1 group with a non-active, non-migrated stage (e.g. "legacy"): present,
+	// but neither an active source for migration nor already marked as migrated.
+	bg1LeftoverOffsets := map[TopicPartition]OffsetAndMetadata{
+		{Partition: 0, Topic: "test-topic"}: {Offset: 10},
+	}
+	adapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
+		{GroupId: groupName},
+		{GroupId: "orders-v1v1l1700000000"},
+	}, nil)
+	adapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), groupName).Return(committedOffsets, nil)
+	adapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), "orders-v1v1l1700000000").Return(bg1LeftoverOffsets, nil)
+
+	indexer, err := newOffsetIndexer(ctx, groupName, "test-topic", adapter)
+	assertions.NoError(err)
+
+	corrector := &offsetCorrector{
+		topic:                        "test-topic",
+		indexer:                      indexer,
+		inherit:                      EventualStrategy(),
+		admin:                        adapter,
+		activeOffsetSetupStrategy:    Rewind(5 * time.Minute),
+		candidateOffsetSetupStrategy: Rewind(5 * time.Minute),
+	}
+	current, err := ParseGroupId(groupName)
+	assertions.NoError(err)
+
+	adapter.EXPECT().PartitionsFor(gomock.Any(), "test-topic").Return([]PartitionInfo{{Partition: 0, Topic: "test-topic"}}, nil)
+	// No AlterConsumerGroupOffsets expectation: bg1VersionsExist()=true but
+	// bg1VersionsMigrated()=false (no active-stage BG1 group to migrate from), so
+	// createMigrationDoneFromBg1MarkerGroup logs a warning and returns nil without altering
+	// anything - the existing group's own offsets must remain untouched.
+	err = corrector.align(ctx, current)
 	assertions.NoError(err)
 }
 
@@ -118,15 +227,37 @@ func TestOffsetCorrector_Install_StrategyEarliest(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	partitions := []PartitionInfo{{Partition: 0, Topic: "test-topic"}}
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 	expectedOffsets := map[TopicPartition]int64{{Partition: 0, Topic: "test-topic"}: 100}
 
-	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(partitions, nil)
-	adapter.EXPECT().BeginningOffsets(ctx, []TopicPartition{{Partition: 0, Topic: "test-topic"}}).Return(expectedOffsets, nil)
+	adapter.EXPECT().BeginningOffsets(ctx, topicPartitions).Return(expectedOffsets, nil)
 
-	result, err := corrector.install(ctx, StrategyEarliest)
+	result, err := corrector.install(ctx, StrategyEarliest, topicPartitions)
 	assertions.NoError(err)
 	assertions.Equal(map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 100}}, result)
+}
+
+func TestOffsetCorrector_Install_StrategyEarliest_MissingPartition(t *testing.T) {
+	assertions := require.New(t)
+	controller := gomock.NewController(t)
+	adapter := NewMockNativeAdminAdapter(controller)
+	corrector := &offsetCorrector{
+		topic: "test-topic",
+		admin: adapter,
+	}
+
+	ctx := context.Background()
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}, {Partition: 1, Topic: "test-topic"}}
+	// BeginningOffsets omits partition 1 entirely (e.g. adapter request-construction bug) -
+	// the corrector must error rather than silently omitting that partition from the alter.
+	adapter.EXPECT().BeginningOffsets(ctx, topicPartitions).Return(map[TopicPartition]int64{
+		{Partition: 0, Topic: "test-topic"}: 100,
+	}, nil)
+
+	result, err := corrector.install(ctx, StrategyEarliest, topicPartitions)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "no BeginningOffsets result")
+	assertions.Nil(result)
 }
 
 func TestOffsetCorrector_Install_StrategyLatest(t *testing.T) {
@@ -139,15 +270,35 @@ func TestOffsetCorrector_Install_StrategyLatest(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	partitions := []PartitionInfo{{Partition: 0, Topic: "test-topic"}}
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 	expectedOffsets := map[TopicPartition]int64{{Partition: 0, Topic: "test-topic"}: 200}
 
-	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(partitions, nil)
-	adapter.EXPECT().EndOffsets(ctx, []TopicPartition{{Partition: 0, Topic: "test-topic"}}).Return(expectedOffsets, nil)
+	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(expectedOffsets, nil)
 
-	result, err := corrector.install(ctx, StrategyLatest)
+	result, err := corrector.install(ctx, StrategyLatest, topicPartitions)
 	assertions.NoError(err)
 	assertions.Equal(map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 200}}, result)
+}
+
+func TestOffsetCorrector_Install_StrategyLatest_MissingPartition(t *testing.T) {
+	assertions := require.New(t)
+	controller := gomock.NewController(t)
+	adapter := NewMockNativeAdminAdapter(controller)
+	corrector := &offsetCorrector{
+		topic: "test-topic",
+		admin: adapter,
+	}
+
+	ctx := context.Background()
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}, {Partition: 1, Topic: "test-topic"}}
+	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(map[TopicPartition]int64{
+		{Partition: 0, Topic: "test-topic"}: 200,
+	}, nil)
+
+	result, err := corrector.install(ctx, StrategyLatest, topicPartitions)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "no EndOffsets result")
+	assertions.Nil(result)
 }
 
 func TestOffsetCorrector_Install_StrategyRewind(t *testing.T) {
@@ -160,16 +311,15 @@ func TestOffsetCorrector_Install_StrategyRewind(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	partitions := []PartitionInfo{{Partition: 0, Topic: "test-topic"}}
 	topicPartition := TopicPartition{Partition: 0, Topic: "test-topic"}
+	topicPartitions := []TopicPartition{topicPartition}
 	expectedTimes := map[TopicPartition]*OffsetAndTimestamp{topicPartition: {Offset: 150, Timestamp: 1234567890}}
 	expectedEndOffsets := map[TopicPartition]int64{topicPartition: 200}
 
-	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(partitions, nil)
 	adapter.EXPECT().OffsetsForTimes(gomock.Any(), gomock.Any()).Return(expectedTimes, nil)
-	adapter.EXPECT().EndOffsets(ctx, []TopicPartition{topicPartition}).Return(expectedEndOffsets, nil)
+	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(expectedEndOffsets, nil)
 
-	result, err := corrector.install(ctx, Rewind(5*time.Minute))
+	result, err := corrector.install(ctx, Rewind(5*time.Minute), topicPartitions)
 	assertions.NoError(err)
 	assertions.Equal(map[TopicPartition]OffsetAndMetadata{topicPartition: {Offset: 150}}, result)
 }
@@ -184,21 +334,44 @@ func TestOffsetCorrector_Install_StrategyRewindWithNilOffset(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	partitions := []PartitionInfo{{Partition: 0, Topic: "test-topic"}}
 	topicPartition := TopicPartition{Partition: 0, Topic: "test-topic"}
+	topicPartitions := []TopicPartition{topicPartition}
 	expectedTimes := map[TopicPartition]*OffsetAndTimestamp{topicPartition: nil} // nil offset
 	expectedEndOffsets := map[TopicPartition]int64{topicPartition: 200}
 
-	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(partitions, nil)
 	adapter.EXPECT().OffsetsForTimes(gomock.Any(), gomock.Any()).Return(expectedTimes, nil)
-	adapter.EXPECT().EndOffsets(ctx, []TopicPartition{topicPartition}).Return(expectedEndOffsets, nil)
+	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(expectedEndOffsets, nil)
 
-	result, err := corrector.install(ctx, Rewind(5*time.Minute))
+	result, err := corrector.install(ctx, Rewind(5*time.Minute), topicPartitions)
 	assertions.NoError(err)
 	assertions.Equal(map[TopicPartition]OffsetAndMetadata{topicPartition: {Offset: 200}}, result)
 }
 
-func TestOffsetCorrector_Install_PartitionsForError(t *testing.T) {
+func TestOffsetCorrector_Install_StrategyRewind_PartitionMissingFromOffsetsForTimes(t *testing.T) {
+	assertions := require.New(t)
+	controller := gomock.NewController(t)
+	adapter := NewMockNativeAdminAdapter(controller)
+	corrector := &offsetCorrector{
+		topic: "test-topic",
+		admin: adapter,
+	}
+
+	ctx := context.Background()
+	topicPartition := TopicPartition{Partition: 0, Topic: "test-topic"}
+	topicPartitions := []TopicPartition{topicPartition}
+	// The partition is entirely absent from the OffsetsForTimes response (not just present
+	// with a nil value) - the corrector must still fall back to EndOffsets for it.
+	expectedEndOffsets := map[TopicPartition]int64{topicPartition: 200}
+
+	adapter.EXPECT().OffsetsForTimes(gomock.Any(), gomock.Any()).Return(map[TopicPartition]*OffsetAndTimestamp{}, nil)
+	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(expectedEndOffsets, nil)
+
+	result, err := corrector.install(ctx, Rewind(5*time.Minute), topicPartitions)
+	assertions.NoError(err)
+	assertions.Equal(map[TopicPartition]OffsetAndMetadata{topicPartition: {Offset: 200}}, result)
+}
+
+func TestOffsetCorrector_topicPartitions_Error(t *testing.T) {
 	assertions := require.New(t)
 	controller := gomock.NewController(t)
 	adapter := NewMockNativeAdminAdapter(controller)
@@ -212,7 +385,7 @@ func TestOffsetCorrector_Install_PartitionsForError(t *testing.T) {
 
 	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(nil, expectedErr)
 
-	result, err := corrector.install(ctx, StrategyEarliest)
+	result, err := corrector.topicPartitions(ctx)
 	assertions.Error(err)
 	assertions.ErrorIs(err, expectedErr)
 	assertions.Nil(result)
@@ -228,13 +401,12 @@ func TestOffsetCorrector_Install_BeginningOffsetsError(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	partitions := []PartitionInfo{{Partition: 0, Topic: "test-topic"}}
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 	expectedErr := errors.New("beginning offsets error")
 
-	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(partitions, nil)
-	adapter.EXPECT().BeginningOffsets(ctx, []TopicPartition{{Partition: 0, Topic: "test-topic"}}).Return(nil, expectedErr)
+	adapter.EXPECT().BeginningOffsets(ctx, topicPartitions).Return(nil, expectedErr)
 
-	result, err := corrector.install(ctx, StrategyEarliest)
+	result, err := corrector.install(ctx, StrategyEarliest, topicPartitions)
 	assertions.Error(err)
 	assertions.Contains(err.Error(), "failed to calculate BeginningOffsets")
 	assertions.Nil(result)
@@ -250,13 +422,12 @@ func TestOffsetCorrector_Install_EndOffsetsError(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	partitions := []PartitionInfo{{Partition: 0, Topic: "test-topic"}}
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 	expectedErr := errors.New("end offsets error")
 
-	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(partitions, nil)
-	adapter.EXPECT().EndOffsets(ctx, []TopicPartition{{Partition: 0, Topic: "test-topic"}}).Return(nil, expectedErr)
+	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(nil, expectedErr)
 
-	result, err := corrector.install(ctx, StrategyLatest)
+	result, err := corrector.install(ctx, StrategyLatest, topicPartitions)
 	assertions.Error(err)
 	assertions.Contains(err.Error(), "failed to calculate EndOffsets")
 	assertions.Nil(result)
@@ -272,15 +443,39 @@ func TestOffsetCorrector_Install_OffsetsForTimesError(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	partitions := []PartitionInfo{{Partition: 0, Topic: "test-topic"}}
+	topicPartitions := []TopicPartition{{Partition: 0, Topic: "test-topic"}}
 	expectedErr := errors.New("offsets for times error")
 
-	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(partitions, nil)
 	adapter.EXPECT().OffsetsForTimes(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
 
-	result, err := corrector.install(ctx, Rewind(5*time.Minute))
+	result, err := corrector.install(ctx, Rewind(5*time.Minute), topicPartitions)
 	assertions.Error(err)
 	assertions.Contains(err.Error(), "failed to calculate OffsetsForTimes")
+	assertions.Nil(result)
+}
+
+func TestOffsetCorrector_Install_StrategyRewind_MissingFallback(t *testing.T) {
+	assertions := require.New(t)
+	controller := gomock.NewController(t)
+	adapter := NewMockNativeAdminAdapter(controller)
+	corrector := &offsetCorrector{
+		topic: "test-topic",
+		admin: adapter,
+	}
+
+	ctx := context.Background()
+	topicPartition := TopicPartition{Partition: 0, Topic: "test-topic"}
+	topicPartitions := []TopicPartition{topicPartition}
+	expectedTimes := map[TopicPartition]*OffsetAndTimestamp{topicPartition: nil} // no record at/after the timestamp
+
+	adapter.EXPECT().OffsetsForTimes(gomock.Any(), gomock.Any()).Return(expectedTimes, nil)
+	// EndOffsets omits the partition entirely (e.g. adapter request-construction bug) -
+	// the corrector must error rather than silently committing offset 0.
+	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(map[TopicPartition]int64{}, nil)
+
+	result, err := corrector.install(ctx, Rewind(5*time.Minute), topicPartitions)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "no EndOffsets fallback available")
 	assertions.Nil(result)
 }
 
@@ -294,16 +489,15 @@ func TestOffsetCorrector_Install_OffsetsForTimesEndOffsetsError(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	partitions := []PartitionInfo{{Partition: 0, Topic: "test-topic"}}
 	topicPartition := TopicPartition{Partition: 0, Topic: "test-topic"}
+	topicPartitions := []TopicPartition{topicPartition}
 	expectedTimes := map[TopicPartition]*OffsetAndTimestamp{topicPartition: {Offset: 150, Timestamp: 1234567890}}
 	expectedErr := errors.New("end offsets error")
 
-	adapter.EXPECT().PartitionsFor(ctx, "test-topic").Return(partitions, nil)
 	adapter.EXPECT().OffsetsForTimes(gomock.Any(), gomock.Any()).Return(expectedTimes, nil)
-	adapter.EXPECT().EndOffsets(ctx, []TopicPartition{topicPartition}).Return(nil, expectedErr)
+	adapter.EXPECT().EndOffsets(ctx, topicPartitions).Return(nil, expectedErr)
 
-	result, err := corrector.install(ctx, Rewind(5*time.Minute))
+	result, err := corrector.install(ctx, Rewind(5*time.Minute), topicPartitions)
 	assertions.Error(err)
 	assertions.Contains(err.Error(), "failed to calculate EndOffsets")
 	assertions.Nil(result)

--- a/indexer.go
+++ b/indexer.go
@@ -3,7 +3,6 @@ package blue_green_kafka
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 )
@@ -11,7 +10,8 @@ import (
 //go:generate mockgen -source=indexer.go -destination=indexer_mock.go -package=blue_green_kafka -mock_names=offsetsIndexer=MockOffsetsIndexer
 
 type offsetsIndexer interface {
-	exists(search GroupId) bool
+	// exists reports whether search already has committed offsets for every one of partitions.
+	exists(search GroupId, partitions []TopicPartition) bool
 	bg1VersionsExist() bool
 	bg1VersionsMigrated() bool
 	findPreviousStateOffset(ctx context.Context, current GroupId) []groupIdWithOffset
@@ -20,7 +20,10 @@ type offsetsIndexer interface {
 
 type offsetsIndexerImpl struct {
 	topic string
-	index map[GroupId]map[TopicPartition]OffsetAndMetadata
+	// keyed by GroupId.String() rather than the GroupId interface value itself: GroupId
+	// implementations are pointers, so map keys of type GroupId compare by address, not
+	// by content, and would never match a freshly-parsed GroupId with the same name.
+	index map[string]groupIdWithOffset
 	admin NativeAdminAdapter
 }
 
@@ -38,7 +41,7 @@ type ConsumerGroup struct {
 }
 
 func newOffsetIndexer(ctx context.Context, groupIdPrefix string, topic string, adminAdapter NativeAdminAdapter) (*offsetsIndexerImpl, error) {
-	index := make(map[GroupId]map[TopicPartition]OffsetAndMetadata)
+	index := make(map[string]groupIdWithOffset)
 	groups, err := adminAdapter.ListConsumerGroups(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list consumer groups: %w", err)
@@ -59,22 +62,43 @@ func newOffsetIndexer(ctx context.Context, groupIdPrefix string, topic string, a
 		if err != nil {
 			return nil, fmt.Errorf("failed to list consumer group offsets: %w", err)
 		}
-		logger.InfoC(ctx, "Offsets=%+v", offsets)
-		logger.InfoC(ctx, "Adding to index groupId=%s with offset: %+v", groupId.String(), offsets)
-		index[groupId] = offsets
+		// A consumer group can carry committed offsets for topics other than this indexer's
+		// topic (e.g. the same group id used across topics). Only offsets for our own topic
+		// are relevant to ancestor lookup and to "does this group already exist" checks.
+		topicOffsets := make(map[TopicPartition]OffsetAndMetadata, len(offsets))
+		for tp, o := range offsets {
+			if tp.Topic == topic {
+				topicOffsets[tp] = o
+			}
+		}
+		if len(topicOffsets) == 0 {
+			// no committed offsets for this topic; treat the group as not yet indexed so the
+			// corrector still runs initial installation/inheritance for it
+			continue
+		}
+		logger.InfoC(ctx, "Offsets=%+v", topicOffsets)
+		logger.InfoC(ctx, "Adding to index groupId=%s with offset: %+v", groupId.String(), topicOffsets)
+		index[groupId.String()] = groupIdWithOffset{groupId: groupId, offset: topicOffsets}
 	}
 	return &offsetsIndexerImpl{topic: topic, index: index, admin: adminAdapter}, nil
 }
 
-func (indexer *offsetsIndexerImpl) exists(search GroupId) bool {
-	_, ok := indexer.index[search]
-	return ok
+func (indexer *offsetsIndexerImpl) exists(search GroupId, partitions []TopicPartition) bool {
+	e, ok := indexer.index[search.String()]
+	if !ok {
+		return false
+	}
+	for _, tp := range partitions {
+		if _, ok := e.offset[tp]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (indexer *offsetsIndexerImpl) bg1VersionsExist() bool {
-	for g := range indexer.index {
-		_, ok := g.(*BG1VersionedGroupId)
-		if ok {
+	for _, e := range indexer.index {
+		if _, ok := e.groupId.(*BG1VersionedGroupId); ok {
 			return true
 		}
 	}
@@ -82,9 +106,8 @@ func (indexer *offsetsIndexerImpl) bg1VersionsExist() bool {
 }
 
 func (indexer *offsetsIndexerImpl) bg1VersionsMigrated() bool {
-	for g := range indexer.index {
-		bg1g, ok := g.(*BG1VersionedGroupId)
-		if ok && bg1g.Stage == bg1StageMigrated {
+	for _, e := range indexer.index {
+		if bg1g, ok := e.groupId.(*BG1VersionedGroupId); ok && bg1g.Stage == bg1StageMigrated {
 			return true
 		}
 	}
@@ -92,10 +115,10 @@ func (indexer *offsetsIndexerImpl) bg1VersionsMigrated() bool {
 }
 
 func (indexer *offsetsIndexerImpl) createMigrationDoneFromBg1MarkerGroup(ctx context.Context) error {
-	filtered := map[GroupId]map[TopicPartition]OffsetAndMetadata{}
-	for g, tpOffset := range indexer.index {
-		if vg, ok := g.(*BG1VersionedGroupId); ok && vg.Stage == bg1StageActive {
-			filtered[vg] = tpOffset
+	var filtered []groupIdWithOffset
+	for _, e := range indexer.index {
+		if vg, ok := e.groupId.(*BG1VersionedGroupId); ok && vg.Stage == bg1StageActive {
+			filtered = append(filtered, e)
 		}
 	}
 	latestGroupOffset := getLatestGroupOffset(filtered)
@@ -109,7 +132,7 @@ func (indexer *offsetsIndexerImpl) createMigrationDoneFromBg1MarkerGroup(ctx con
 			Updated:          time.Now(),
 		}
 		logger.InfoC(ctx, "Creating migrated from BG1 marker Group: %s", migratedMarkerGroup.String())
-		return indexer.admin.AlterConsumerGroupOffsets(ctx, migratedMarkerGroup, indexer.index[bg1vg])
+		return indexer.admin.AlterConsumerGroupOffsets(ctx, migratedMarkerGroup, latestGroupOffset.offset)
 	} else {
 		logger.WarnC(ctx, "Did not create 'migrated from BG1 marker Group' because no bg1 active group was found")
 		return nil
@@ -118,50 +141,44 @@ func (indexer *offsetsIndexerImpl) createMigrationDoneFromBg1MarkerGroup(ctx con
 
 func (indexer *offsetsIndexerImpl) findPreviousStateOffset(ctx context.Context, current GroupId) []groupIdWithOffset {
 	logger.InfoC(ctx, "Search the ancestor for: %s", current)
-	filtered := map[GroupId]map[TopicPartition]OffsetAndMetadata{}
+	currentKey := current.String()
+	var filtered []groupIdWithOffset
 
-	for gId, tpOffset := range indexer.index {
+	for key, e := range indexer.index {
 		// filter out current group
-		if gId == current {
+		if key == currentKey {
 			continue
 		}
 		// filter out offsets of the same update time (already created in sibling ns)
-		if vg, ok1 := gId.(*VersionedGroupId); ok1 {
+		if vg, ok1 := e.groupId.(*VersionedGroupId); ok1 {
 			if vCurrent, ok2 := current.(*VersionedGroupId); ok2 &&
 				(vg.Updated.Equal(vCurrent.Updated) || vg.Updated.After(vCurrent.Updated)) {
 				continue
 			}
 		}
-		filtered[gId] = tpOffset
+		filtered = append(filtered, e)
 	}
 	// find latest groupId
 	latestGroupOffset := getLatestGroupOffset(filtered)
-	var latestGroups []GroupId
+	var result []groupIdWithOffset
 	if latestGroupOffset != nil {
 		// if latest groupId is versioned - find all groupIds of the same updateTime
 		if vg1, ok1 := latestGroupOffset.groupId.(*VersionedGroupId); ok1 {
-			for g2 := range indexer.index {
-				if vg2, ok2 := g2.(*VersionedGroupId); ok2 && vg2.Updated.Equal(vg1.Updated) {
-					latestGroups = append(latestGroups, g2)
+			for _, e := range indexer.index {
+				if vg2, ok2 := e.groupId.(*VersionedGroupId); ok2 && vg2.Updated.Equal(vg1.Updated) {
+					result = append(result, e)
 				}
 			}
 		} else if vg1, ok1 := latestGroupOffset.groupId.(*BG1VersionedGroupId); ok1 {
 			// old blue-green groupId, we are interested only in active groupId
-			for g2 := range indexer.index {
-				if vg2, ok2 := g2.(*BG1VersionedGroupId); ok2 && vg2.Updated.Equal(vg1.Updated) && vg2.Stage == bg1StageActive {
-					latestGroups = append(latestGroups, g2)
+			for _, e := range indexer.index {
+				if vg2, ok2 := e.groupId.(*BG1VersionedGroupId); ok2 && vg2.Updated.Equal(vg1.Updated) && vg2.Stage == bg1StageActive {
+					result = append(result, e)
 				}
 			}
 		} else {
-			latestGroups = append(latestGroups, latestGroupOffset.groupId)
+			result = append(result, *latestGroupOffset)
 		}
-	}
-	var result []groupIdWithOffset
-	for _, g := range latestGroups {
-		result = append(result, groupIdWithOffset{
-			groupId: g,
-			offset:  indexer.index[g],
-		})
 	}
 	if len(result) > 0 {
 		var previousStrs []string
@@ -175,32 +192,14 @@ func (indexer *offsetsIndexerImpl) findPreviousStateOffset(ctx context.Context, 
 	return result
 }
 
-func getLatestGroupOffset(index map[GroupId]map[TopicPartition]OffsetAndMetadata) *groupIdWithOffset {
-	result := getSortedIndexKeys(index)
-	length := len(result)
-	if length > 0 {
-		return &result[length-1]
-	} else {
-		return nil
+func getLatestGroupOffset(entries []groupIdWithOffset) *groupIdWithOffset {
+	var latest *groupIdWithOffset
+	for i := range entries {
+		if latest == nil || getSortKeyFromGroup(entries[i].groupId).After(getSortKeyFromGroup(latest.groupId)) {
+			latest = &entries[i]
+		}
 	}
-}
-
-func getSortedIndexKeys(index map[GroupId]map[TopicPartition]OffsetAndMetadata) []groupIdWithOffset {
-	keys := make([]GroupId, 0, len(index))
-	for g := range index {
-		keys = append(keys, g)
-	}
-	sort.Slice(keys, func(gi1, gi2 int) bool {
-		return getSortKeyFromGroup(keys[gi1]).Before(getSortKeyFromGroup(keys[gi2]))
-	})
-	result := make([]groupIdWithOffset, 0, len(index))
-	for _, g := range keys {
-		result = append(result, groupIdWithOffset{
-			groupId: g,
-			offset:  index[g],
-		})
-	}
-	return result
+	return latest
 }
 
 var minTime = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/indexer.go
+++ b/indexer.go
@@ -62,10 +62,11 @@ func newOffsetIndexer(ctx context.Context, groupIdPrefix string, topic string, a
 		if err != nil {
 			return nil, fmt.Errorf("failed to list consumer group offsets: %w", err)
 		}
-		// a group id can carry offsets for other topics too; only ours are relevant here
+		// a group id can carry offsets for other topics too; only ours are relevant here.
+		// A negative offset is Kafka's "no committed offset" sentinel, not a commit.
 		topicOffsets := make(map[TopicPartition]OffsetAndMetadata, len(offsets))
 		for tp, o := range offsets {
-			if tp.Topic == topic {
+			if tp.Topic == topic && o.Offset >= 0 {
 				topicOffsets[tp] = o
 			}
 		}

--- a/indexer.go
+++ b/indexer.go
@@ -20,9 +20,8 @@ type offsetsIndexer interface {
 
 type offsetsIndexerImpl struct {
 	topic string
-	// keyed by GroupId.String() rather than the GroupId interface value itself: GroupId
-	// implementations are pointers, so map keys of type GroupId compare by address, not
-	// by content, and would never match a freshly-parsed GroupId with the same name.
+	// keyed by GroupId.String(): GroupId is pointer-typed, so using it directly as a map
+	// key would compare by address, not by the group it identifies.
 	index map[string]groupIdWithOffset
 	admin NativeAdminAdapter
 }
@@ -62,9 +61,7 @@ func newOffsetIndexer(ctx context.Context, groupIdPrefix string, topic string, a
 		if err != nil {
 			return nil, fmt.Errorf("failed to list consumer group offsets: %w", err)
 		}
-		// A consumer group can carry committed offsets for topics other than this indexer's
-		// topic (e.g. the same group id used across topics). Only offsets for our own topic
-		// are relevant to ancestor lookup and to "does this group already exist" checks.
+		// a group id can carry offsets for other topics too; only ours are relevant here
 		topicOffsets := make(map[TopicPartition]OffsetAndMetadata, len(offsets))
 		for tp, o := range offsets {
 			if tp.Topic == topic {
@@ -72,9 +69,7 @@ func newOffsetIndexer(ctx context.Context, groupIdPrefix string, topic string, a
 			}
 		}
 		if len(topicOffsets) == 0 {
-			// no committed offsets for this topic; treat the group as not yet indexed so the
-			// corrector still runs initial installation/inheritance for it
-			continue
+			continue // no offsets for this topic; treat as not yet indexed
 		}
 		logger.InfoC(ctx, "Offsets=%+v", topicOffsets)
 		logger.InfoC(ctx, "Adding to index groupId=%s with offset: %+v", groupId.String(), topicOffsets)

--- a/indexer.go
+++ b/indexer.go
@@ -10,8 +10,9 @@ import (
 //go:generate mockgen -source=indexer.go -destination=indexer_mock.go -package=blue_green_kafka -mock_names=offsetsIndexer=MockOffsetsIndexer
 
 type offsetsIndexer interface {
-	// exists reports whether search already has committed offsets for every one of partitions.
-	exists(search GroupId, partitions []TopicPartition) bool
+	// committedOffsets returns the offsets search has committed for the indexer's topic,
+	// or nil when the group has none.
+	committedOffsets(search GroupId) map[TopicPartition]OffsetAndMetadata
 	bg1VersionsExist() bool
 	bg1VersionsMigrated() bool
 	findPreviousStateOffset(ctx context.Context, current GroupId) []groupIdWithOffset
@@ -78,17 +79,11 @@ func newOffsetIndexer(ctx context.Context, groupIdPrefix string, topic string, a
 	return &offsetsIndexerImpl{topic: topic, index: index, admin: adminAdapter}, nil
 }
 
-func (indexer *offsetsIndexerImpl) exists(search GroupId, partitions []TopicPartition) bool {
-	e, ok := indexer.index[search.String()]
-	if !ok {
-		return false
+func (indexer *offsetsIndexerImpl) committedOffsets(search GroupId) map[TopicPartition]OffsetAndMetadata {
+	if e, ok := indexer.index[search.String()]; ok {
+		return e.offset
 	}
-	for _, tp := range partitions {
-		if _, ok := e.offset[tp]; !ok {
-			return false
-		}
-	}
-	return true
+	return nil
 }
 
 func (indexer *offsetsIndexerImpl) bg1VersionsExist() bool {

--- a/indexer_mock.go
+++ b/indexer_mock.go
@@ -76,18 +76,18 @@ func (mr *MockOffsetsIndexerMockRecorder) createMigrationDoneFromBg1MarkerGroup(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "createMigrationDoneFromBg1MarkerGroup", reflect.TypeOf((*MockOffsetsIndexer)(nil).createMigrationDoneFromBg1MarkerGroup), ctx)
 }
 
-// exists mocks base method.
-func (m *MockOffsetsIndexer) exists(search GroupId, partitions []TopicPartition) bool {
+// committedOffsets mocks base method.
+func (m *MockOffsetsIndexer) committedOffsets(search GroupId) map[TopicPartition]OffsetAndMetadata {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "exists", search, partitions)
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "committedOffsets", search)
+	ret0, _ := ret[0].(map[TopicPartition]OffsetAndMetadata)
 	return ret0
 }
 
-// exists indicates an expected call of exists.
-func (mr *MockOffsetsIndexerMockRecorder) exists(search, partitions interface{}) *gomock.Call {
+// committedOffsets indicates an expected call of committedOffsets.
+func (mr *MockOffsetsIndexerMockRecorder) committedOffsets(search interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "exists", reflect.TypeOf((*MockOffsetsIndexer)(nil).exists), search, partitions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "committedOffsets", reflect.TypeOf((*MockOffsetsIndexer)(nil).committedOffsets), search)
 }
 
 // findPreviousStateOffset mocks base method.

--- a/indexer_mock.go
+++ b/indexer_mock.go
@@ -77,17 +77,17 @@ func (mr *MockOffsetsIndexerMockRecorder) createMigrationDoneFromBg1MarkerGroup(
 }
 
 // exists mocks base method.
-func (m *MockOffsetsIndexer) exists(search GroupId) bool {
+func (m *MockOffsetsIndexer) exists(search GroupId, partitions []TopicPartition) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "exists", search)
+	ret := m.ctrl.Call(m, "exists", search, partitions)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // exists indicates an expected call of exists.
-func (mr *MockOffsetsIndexerMockRecorder) exists(search interface{}) *gomock.Call {
+func (mr *MockOffsetsIndexerMockRecorder) exists(search, partitions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "exists", reflect.TypeOf((*MockOffsetsIndexer)(nil).exists), search)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "exists", reflect.TypeOf((*MockOffsetsIndexer)(nil).exists), search, partitions)
 }
 
 // findPreviousStateOffset mocks base method.

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -83,9 +83,95 @@ func TestOffsetIndexer_exists(t *testing.T) {
 		assertions.NoError(err)
 
 		groupId := MustParseGroupId("nonexistent-group")
-		result := indexer.exists(groupId)
+		result := indexer.exists(groupId, []TopicPartition{{Partition: 0, Topic: "test-topic"}})
 		assertions.False(result)
 	})
+
+	t.Run("should return true when group exists, even parsed as a distinct GroupId instance", func(t *testing.T) {
+		// Regression test: GroupId implementations are pointers allocated fresh by
+		// ParseGroupId, so exists() must compare by content (GroupId.String()), not by
+		// the GroupId interface value's address, or an existing group would never be
+		// recognized as already indexed.
+		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
+		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
+			{GroupId: "test"},
+		}, nil)
+		nativeAdminAdapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), "test").Return(
+			map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 42}}, nil)
+
+		indexer, err := newOffsetIndexer(ctx, "test", "test-topic", nativeAdminAdapter)
+		assertions.NoError(err)
+
+		search, err := ParseGroupId("test") // freshly allocated, distinct pointer from the one indexed above
+		assertions.NoError(err)
+		result := indexer.exists(search, []TopicPartition{{Partition: 0, Topic: "test-topic"}})
+		assertions.True(result)
+	})
+
+	t.Run("should return false when the group has offsets on only a subset of the requested partitions", func(t *testing.T) {
+		// Regression test: a group that has only partially committed offsets (e.g. a topic
+		// partition count increase, or a crash mid-alter) must not be treated as fully
+		// initialized, or the missing partitions would never get an install/inherit pass.
+		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
+		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
+			{GroupId: "test"},
+		}, nil)
+		nativeAdminAdapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), "test").Return(
+			map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 42}}, nil)
+
+		indexer, err := newOffsetIndexer(ctx, "test", "test-topic", nativeAdminAdapter)
+		assertions.NoError(err)
+
+		search := MustParseGroupId("test")
+		result := indexer.exists(search, []TopicPartition{
+			{Partition: 0, Topic: "test-topic"},
+			{Partition: 1, Topic: "test-topic"}, // no committed offset for this partition
+		})
+		assertions.False(result)
+	})
+
+	t.Run("should return false when the group's committed offsets are for a different topic", func(t *testing.T) {
+		// Regression test: offsetsIndexerImpl.topic must actually be used to filter
+		// ListConsumerGroupOffsets results. A group id shared across topics (or one that
+		// only ever consumed a different topic) must not be treated as existing for this
+		// indexer's topic merely because Kafka has some committed offsets under that name.
+		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
+		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
+			{GroupId: "test"},
+		}, nil)
+		nativeAdminAdapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), "test").Return(
+			map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "other-topic"}: {Offset: 42}}, nil)
+
+		indexer, err := newOffsetIndexer(ctx, "test", "test-topic", nativeAdminAdapter)
+		assertions.NoError(err)
+
+		search := MustParseGroupId("test")
+		result := indexer.exists(search, []TopicPartition{{Partition: 0, Topic: "test-topic"}})
+		assertions.False(result)
+	})
+}
+
+func TestOffsetIndexer_findPreviousStateOffset_excludesCurrentGroup(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	// Regression test: a plain group must never be offered its own committed offsets as
+	// an "ancestor" merely because the current GroupId is a distinct, freshly-parsed
+	// pointer with the same name as the one already indexed.
+	nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
+	nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
+		{GroupId: "test"},
+	}, nil)
+	nativeAdminAdapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), "test").Return(
+		map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 42}}, nil)
+
+	indexer, err := newOffsetIndexer(ctx, "test", "test-topic", nativeAdminAdapter)
+	assertions.NoError(err)
+
+	current, err := ParseGroupId("test")
+	assertions.NoError(err)
+	result := indexer.findPreviousStateOffset(ctx, current)
+	assertions.Empty(result)
 }
 
 func TestOffsetIndexer_bg1VersionsExist(t *testing.T) {

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -71,11 +71,11 @@ func TestMigrationDoesNotExist(t *testing.T) {
 	assertions.NoError(err)
 }
 
-func TestOffsetIndexer_exists(t *testing.T) {
+func TestOffsetIndexer_committedOffsets(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 
-	t.Run("should return false when group does not exist", func(t *testing.T) {
+	t.Run("should return nil when group does not exist", func(t *testing.T) {
 		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
 		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{}, nil)
 
@@ -83,11 +83,10 @@ func TestOffsetIndexer_exists(t *testing.T) {
 		assertions.NoError(err)
 
 		groupId := MustParseGroupId("nonexistent-group")
-		result := indexer.exists(groupId, []TopicPartition{{Partition: 0, Topic: "test-topic"}})
-		assertions.False(result)
+		assertions.Nil(indexer.committedOffsets(groupId))
 	})
 
-	t.Run("should return true when group exists, even parsed as a distinct GroupId instance", func(t *testing.T) {
+	t.Run("should return the group's offsets, even searched as a distinct GroupId instance", func(t *testing.T) {
 		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
 		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
 			{GroupId: "test"},
@@ -100,30 +99,11 @@ func TestOffsetIndexer_exists(t *testing.T) {
 
 		search, err := ParseGroupId("test") // freshly allocated, distinct pointer from the one indexed above
 		assertions.NoError(err)
-		result := indexer.exists(search, []TopicPartition{{Partition: 0, Topic: "test-topic"}})
-		assertions.True(result)
+		result := indexer.committedOffsets(search)
+		assertions.Equal(map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 42}}, result)
 	})
 
-	t.Run("should return false when the group has offsets on only a subset of the requested partitions", func(t *testing.T) {
-		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
-		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
-			{GroupId: "test"},
-		}, nil)
-		nativeAdminAdapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), "test").Return(
-			map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 42}}, nil)
-
-		indexer, err := newOffsetIndexer(ctx, "test", "test-topic", nativeAdminAdapter)
-		assertions.NoError(err)
-
-		search := MustParseGroupId("test")
-		result := indexer.exists(search, []TopicPartition{
-			{Partition: 0, Topic: "test-topic"},
-			{Partition: 1, Topic: "test-topic"}, // no committed offset for this partition
-		})
-		assertions.False(result)
-	})
-
-	t.Run("should return false when the group's committed offsets are for a different topic", func(t *testing.T) {
+	t.Run("should return nil when the group's committed offsets are for a different topic", func(t *testing.T) {
 		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
 		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
 			{GroupId: "test"},
@@ -135,8 +115,7 @@ func TestOffsetIndexer_exists(t *testing.T) {
 		assertions.NoError(err)
 
 		search := MustParseGroupId("test")
-		result := indexer.exists(search, []TopicPartition{{Partition: 0, Topic: "test-topic"}})
-		assertions.False(result)
+		assertions.Nil(indexer.committedOffsets(search))
 	})
 }
 

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -103,6 +103,24 @@ func TestOffsetIndexer_committedOffsets(t *testing.T) {
 		assertions.Equal(map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 42}}, result)
 	})
 
+	t.Run("should exclude partitions reported with a negative (uncommitted) sentinel offset", func(t *testing.T) {
+		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
+		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
+			{GroupId: "test"},
+		}, nil)
+		nativeAdminAdapter.EXPECT().ListConsumerGroupOffsets(gomock.Any(), "test").Return(
+			map[TopicPartition]OffsetAndMetadata{
+				{Partition: 0, Topic: "test-topic"}: {Offset: 42},
+				{Partition: 1, Topic: "test-topic"}: {Offset: -1}, // no committed offset
+			}, nil)
+
+		indexer, err := newOffsetIndexer(ctx, "test", "test-topic", nativeAdminAdapter)
+		assertions.NoError(err)
+
+		result := indexer.committedOffsets(MustParseGroupId("test"))
+		assertions.Equal(map[TopicPartition]OffsetAndMetadata{{Partition: 0, Topic: "test-topic"}: {Offset: 42}}, result)
+	})
+
 	t.Run("should return nil when the group's committed offsets are for a different topic", func(t *testing.T) {
 		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
 		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -88,10 +88,6 @@ func TestOffsetIndexer_exists(t *testing.T) {
 	})
 
 	t.Run("should return true when group exists, even parsed as a distinct GroupId instance", func(t *testing.T) {
-		// Regression test: GroupId implementations are pointers allocated fresh by
-		// ParseGroupId, so exists() must compare by content (GroupId.String()), not by
-		// the GroupId interface value's address, or an existing group would never be
-		// recognized as already indexed.
 		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
 		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
 			{GroupId: "test"},
@@ -109,9 +105,6 @@ func TestOffsetIndexer_exists(t *testing.T) {
 	})
 
 	t.Run("should return false when the group has offsets on only a subset of the requested partitions", func(t *testing.T) {
-		// Regression test: a group that has only partially committed offsets (e.g. a topic
-		// partition count increase, or a crash mid-alter) must not be treated as fully
-		// initialized, or the missing partitions would never get an install/inherit pass.
 		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
 		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
 			{GroupId: "test"},
@@ -131,10 +124,6 @@ func TestOffsetIndexer_exists(t *testing.T) {
 	})
 
 	t.Run("should return false when the group's committed offsets are for a different topic", func(t *testing.T) {
-		// Regression test: offsetsIndexerImpl.topic must actually be used to filter
-		// ListConsumerGroupOffsets results. A group id shared across topics (or one that
-		// only ever consumed a different topic) must not be treated as existing for this
-		// indexer's topic merely because Kafka has some committed offsets under that name.
 		nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
 		nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
 			{GroupId: "test"},
@@ -155,9 +144,6 @@ func TestOffsetIndexer_findPreviousStateOffset_excludesCurrentGroup(t *testing.T
 	assertions := require.New(t)
 	ctx := context.Background()
 
-	// Regression test: a plain group must never be offered its own committed offsets as
-	// an "ancestor" merely because the current GroupId is a distinct, freshly-parsed
-	// pointer with the same name as the one already indexed.
 	nativeAdminAdapter := NewMockNativeAdminAdapter(gomock.NewController(t))
 	nativeAdminAdapter.EXPECT().ListConsumerGroups(gomock.Any()).Return([]ConsumerGroup{
 		{GroupId: "test"},

--- a/native.go
+++ b/native.go
@@ -39,6 +39,9 @@ type Consumer interface {
 
 type NativeAdminAdapter interface {
 	ListConsumerGroups(ctx context.Context) ([]ConsumerGroup, error)
+	// ListConsumerGroupOffsets returns only partitions the group has actually committed on;
+	// a partition without a committed offset must be omitted, not reported with a negative
+	// sentinel offset.
 	ListConsumerGroupOffsets(ctx context.Context, groupId string) (map[TopicPartition]OffsetAndMetadata, error)
 	AlterConsumerGroupOffsets(ctx context.Context, groupIdPrefix GroupId, proposedOffsets map[TopicPartition]OffsetAndMetadata) error
 	PartitionsFor(ctx context.Context, topics ...string) ([]PartitionInfo, error)

--- a/native.go
+++ b/native.go
@@ -39,7 +39,11 @@ type NativeAdminAdapter interface {
 	ListConsumerGroupOffsets(ctx context.Context, groupId string) (map[TopicPartition]OffsetAndMetadata, error)
 	AlterConsumerGroupOffsets(ctx context.Context, groupIdPrefix GroupId, proposedOffsets map[TopicPartition]OffsetAndMetadata) error
 	PartitionsFor(ctx context.Context, topics ...string) ([]PartitionInfo, error)
+	// BeginningOffsets and EndOffsets must return an entry for every requested TopicPartition.
 	BeginningOffsets(ctx context.Context, topicPartitions []TopicPartition) (map[TopicPartition]int64, error)
 	EndOffsets(ctx context.Context, topicPartitions []TopicPartition) (map[TopicPartition]int64, error)
+	// OffsetsForTimes must return an entry for every requested TopicPartition. A partition with
+	// no record at or after the requested timestamp must map to a nil *OffsetAndTimestamp, not a
+	// fabricated offset (e.g. 0) — callers rely on nil to fall back to EndOffsets.
 	OffsetsForTimes(ctx context.Context, times map[TopicPartition]time.Time) (map[TopicPartition]*OffsetAndTimestamp, error)
 }

--- a/native.go
+++ b/native.go
@@ -29,6 +29,9 @@ type Result struct {
 }
 
 type Consumer interface {
+	// ReadMessage never redelivers within a session: the read position only moves forward,
+	// whether or not the message is committed. Callers must retry a failed message in place,
+	// not by calling ReadMessage again — once a later offset commits, the message is lost.
 	ReadMessage(context.Context) (Message, error)
 	Commit(ctx context.Context, marker *CommitMarker) error
 	Close() error

--- a/native.go
+++ b/native.go
@@ -42,8 +42,6 @@ type NativeAdminAdapter interface {
 	// BeginningOffsets and EndOffsets must return an entry for every requested TopicPartition.
 	BeginningOffsets(ctx context.Context, topicPartitions []TopicPartition) (map[TopicPartition]int64, error)
 	EndOffsets(ctx context.Context, topicPartitions []TopicPartition) (map[TopicPartition]int64, error)
-	// OffsetsForTimes must return an entry for every requested TopicPartition. A partition with
-	// no record at or after the requested timestamp must map to a nil *OffsetAndTimestamp, not a
-	// fabricated offset (e.g. 0) — callers rely on nil to fall back to EndOffsets.
+	// OffsetsForTimes: same, and a partition with no matching record maps to nil, not offset 0.
 	OffsetsForTimes(ctx context.Context, times map[TopicPartition]time.Time) (map[TopicPartition]*OffsetAndTimestamp, error)
 }

--- a/stategyEventual.go
+++ b/stategyEventual.go
@@ -19,7 +19,7 @@ func EventualStrategy() OffsetInheritanceStrategy {
 				result = nil
 			} else {
 				// a plain group's own offsets are never in `previous`; preserving them is
-				// align()'s job via exists(), not this strategy's
+				// align()'s job via committedOffsets(), not this strategy's
 				/* transition from old BG implementation */
 				// inherit from BG1 ACTIVE group
 				for _, gwo := range previous {

--- a/stategyEventual.go
+++ b/stategyEventual.go
@@ -18,6 +18,12 @@ func EventualStrategy() OffsetInheritanceStrategy {
 				/* non BG case */
 				result = nil
 			} else {
+				// Note: a plain group's own previously committed offsets are never present in
+				// `previous` here - the indexer can only ever index one PlainGroupId per prefix
+				// (its own, since PlainGroupId.GetGroupIdPrefix() == Name), and
+				// findPreviousStateOffset excludes the current group from its own ancestor
+				// list. Preserving an existing group's offsets is align()'s job (its exists()
+				// check short-circuits before this strategy ever runs), not this strategy's.
 				/* transition from old BG implementation */
 				// inherit from BG1 ACTIVE group
 				for _, gwo := range previous {

--- a/stategyEventual.go
+++ b/stategyEventual.go
@@ -18,12 +18,8 @@ func EventualStrategy() OffsetInheritanceStrategy {
 				/* non BG case */
 				result = nil
 			} else {
-				// Note: a plain group's own previously committed offsets are never present in
-				// `previous` here - the indexer can only ever index one PlainGroupId per prefix
-				// (its own, since PlainGroupId.GetGroupIdPrefix() == Name), and
-				// findPreviousStateOffset excludes the current group from its own ancestor
-				// list. Preserving an existing group's offsets is align()'s job (its exists()
-				// check short-circuits before this strategy ever runs), not this strategy's.
+				// a plain group's own offsets are never in `previous`; preserving them is
+				// align()'s job via exists(), not this strategy's
 				/* transition from old BG implementation */
 				// inherit from BG1 ACTIVE group
 				for _, gwo := range previous {

--- a/version.go
+++ b/version.go
@@ -8,11 +8,10 @@ import (
 	"time"
 )
 
-// GroupId implementations are pointers: compare with Equals (or String()), never ==.
+// GroupId implementations are pointers: compare String() values, never == directly.
 type GroupId interface {
 	GetGroupIdPrefix() string
 	String() string
-	Equals(other GroupId) bool
 }
 
 type VersionedGroupId struct {
@@ -131,10 +130,6 @@ func (v *VersionedGroupId) String() string {
 		v.GroupIdPrefix, v.Version.String(), v.State.ShortString(), v.SiblingState.ShortString(), FromOffsetDateTime(v.Updated))
 }
 
-func (v *VersionedGroupId) Equals(other GroupId) bool {
-	return other != nil && v.String() == other.String()
-}
-
 func FromOffsetDateTime(dt time.Time) string {
 	return fmt.Sprintf(datePartTemplate, dt.Year(), int(dt.Month()), dt.Day(), dt.Hour(), dt.Minute(), dt.Second())
 }
@@ -177,18 +172,10 @@ func (v *BG1VersionedGroupId) String() string {
 		v.GroupIdPrefix, v.Version.String(), v.BlueGreenVersion.String(), v.Stage, v.Updated.Unix())
 }
 
-func (v *BG1VersionedGroupId) Equals(other GroupId) bool {
-	return other != nil && v.String() == other.String()
-}
-
 func (v *PlainGroupId) GetGroupIdPrefix() string {
 	return v.Name
 }
 
 func (v *PlainGroupId) String() string {
 	return v.Name
-}
-
-func (v *PlainGroupId) Equals(other GroupId) bool {
-	return other != nil && v.String() == other.String()
 }

--- a/version.go
+++ b/version.go
@@ -8,10 +8,7 @@ import (
 	"time"
 )
 
-// GroupId implementations (*VersionedGroupId, *PlainGroupId, *BG1VersionedGroupId) are
-// pointers, so comparing GroupId values with == (or using GroupId as a map key) compares
-// addresses, not group identity, and will never match a separately-parsed GroupId with the
-// same name. Use Equals (or compare String()) instead.
+// GroupId implementations are pointers: compare with Equals (or String()), never ==.
 type GroupId interface {
 	GetGroupIdPrefix() string
 	String() string

--- a/version.go
+++ b/version.go
@@ -8,9 +8,14 @@ import (
 	"time"
 )
 
+// GroupId implementations (*VersionedGroupId, *PlainGroupId, *BG1VersionedGroupId) are
+// pointers, so comparing GroupId values with == (or using GroupId as a map key) compares
+// addresses, not group identity, and will never match a separately-parsed GroupId with the
+// same name. Use Equals (or compare String()) instead.
 type GroupId interface {
 	GetGroupIdPrefix() string
 	String() string
+	Equals(other GroupId) bool
 }
 
 type VersionedGroupId struct {
@@ -129,6 +134,10 @@ func (v *VersionedGroupId) String() string {
 		v.GroupIdPrefix, v.Version.String(), v.State.ShortString(), v.SiblingState.ShortString(), FromOffsetDateTime(v.Updated))
 }
 
+func (v *VersionedGroupId) Equals(other GroupId) bool {
+	return other != nil && v.String() == other.String()
+}
+
 func FromOffsetDateTime(dt time.Time) string {
 	return fmt.Sprintf(datePartTemplate, dt.Year(), int(dt.Month()), dt.Day(), dt.Hour(), dt.Minute(), dt.Second())
 }
@@ -171,10 +180,18 @@ func (v *BG1VersionedGroupId) String() string {
 		v.GroupIdPrefix, v.Version.String(), v.BlueGreenVersion.String(), v.Stage, v.Updated.Unix())
 }
 
+func (v *BG1VersionedGroupId) Equals(other GroupId) bool {
+	return other != nil && v.String() == other.String()
+}
+
 func (v *PlainGroupId) GetGroupIdPrefix() string {
 	return v.Name
 }
 
 func (v *PlainGroupId) String() string {
 	return v.Name
+}
+
+func (v *PlainGroupId) Equals(other GroupId) bool {
+	return other != nil && v.String() == other.String()
 }

--- a/version_test.go
+++ b/version_test.go
@@ -30,19 +30,6 @@ func TestPlainGroupId_String(t *testing.T) {
 	assertions.Equal("plain-group", result)
 }
 
-func TestPlainGroupId_Equals(t *testing.T) {
-	assertions := require.New(t)
-
-	a := MustParseGroupId("plain-group")
-	b, err := ParseGroupId("plain-group") // distinct pointer, same content
-	assertions.NoError(err)
-
-	assertions.True(a.Equals(b))
-	assertions.True(b.Equals(a))
-	assertions.False(a.Equals(MustParseGroupId("other-group")))
-	assertions.False(a.Equals(nil))
-}
-
 func TestVersionedGroupId_GetGroupIdPrefix(t *testing.T) {
 	assertions := require.New(t)
 
@@ -61,18 +48,6 @@ func TestVersionedGroupId_String(t *testing.T) {
 
 	result := vgId.String()
 	assertions.Equal("test-v1-a_i-2023-07-07_10-30-00", result)
-}
-
-func TestVersionedGroupId_Equals(t *testing.T) {
-	assertions := require.New(t)
-
-	a := MustParseGroupId("test-v1-a_i-2023-07-07_10-30-00")
-	b, err := ParseGroupId("test-v1-a_i-2023-07-07_10-30-00") // distinct pointer, same content
-	assertions.NoError(err)
-
-	assertions.True(a.Equals(b))
-	assertions.False(a.Equals(MustParseGroupId("test-v1-a_i-2023-07-07_10-30-01")))
-	assertions.False(a.Equals(MustParseGroupId("plain-group")))
 }
 
 func TestFromOffsetDateTime(t *testing.T) {
@@ -355,33 +330,4 @@ func TestBG1VersionedGroupId_String(t *testing.T) {
 	result := groupId.String()
 	expected := fmt.Sprintf("test-v1v2a1234567890")
 	assert.Equal(t, expected, result)
-}
-
-func TestBG1VersionedGroupId_Equals(t *testing.T) {
-	version := bgMonitor.NewVersionMust("v1")
-	bgVersion := bgMonitor.NewVersionMust("v2")
-	a := &BG1VersionedGroupId{
-		GroupIdPrefix:    "test",
-		Version:          *version,
-		BlueGreenVersion: *bgVersion,
-		Stage:            "a",
-		Updated:          time.Unix(1234567890, 0),
-	}
-	b := &BG1VersionedGroupId{ // distinct pointer, same content
-		GroupIdPrefix:    "test",
-		Version:          *version,
-		BlueGreenVersion: *bgVersion,
-		Stage:            "a",
-		Updated:          time.Unix(1234567890, 0),
-	}
-	other := &BG1VersionedGroupId{
-		GroupIdPrefix:    "test",
-		Version:          *version,
-		BlueGreenVersion: *bgVersion,
-		Stage:            "M",
-		Updated:          time.Unix(1234567890, 0),
-	}
-
-	assert.True(t, a.Equals(b))
-	assert.False(t, a.Equals(other))
 }

--- a/version_test.go
+++ b/version_test.go
@@ -30,6 +30,19 @@ func TestPlainGroupId_String(t *testing.T) {
 	assertions.Equal("plain-group", result)
 }
 
+func TestPlainGroupId_Equals(t *testing.T) {
+	assertions := require.New(t)
+
+	a := MustParseGroupId("plain-group")
+	b, err := ParseGroupId("plain-group") // distinct pointer, same content
+	assertions.NoError(err)
+
+	assertions.True(a.Equals(b))
+	assertions.True(b.Equals(a))
+	assertions.False(a.Equals(MustParseGroupId("other-group")))
+	assertions.False(a.Equals(nil))
+}
+
 func TestVersionedGroupId_GetGroupIdPrefix(t *testing.T) {
 	assertions := require.New(t)
 
@@ -48,6 +61,18 @@ func TestVersionedGroupId_String(t *testing.T) {
 
 	result := vgId.String()
 	assertions.Equal("test-v1-a_i-2023-07-07_10-30-00", result)
+}
+
+func TestVersionedGroupId_Equals(t *testing.T) {
+	assertions := require.New(t)
+
+	a := MustParseGroupId("test-v1-a_i-2023-07-07_10-30-00")
+	b, err := ParseGroupId("test-v1-a_i-2023-07-07_10-30-00") // distinct pointer, same content
+	assertions.NoError(err)
+
+	assertions.True(a.Equals(b))
+	assertions.False(a.Equals(MustParseGroupId("test-v1-a_i-2023-07-07_10-30-01")))
+	assertions.False(a.Equals(MustParseGroupId("plain-group")))
 }
 
 func TestFromOffsetDateTime(t *testing.T) {
@@ -330,4 +355,33 @@ func TestBG1VersionedGroupId_String(t *testing.T) {
 	result := groupId.String()
 	expected := fmt.Sprintf("test-v1v2a1234567890")
 	assert.Equal(t, expected, result)
+}
+
+func TestBG1VersionedGroupId_Equals(t *testing.T) {
+	version := bgMonitor.NewVersionMust("v1")
+	bgVersion := bgMonitor.NewVersionMust("v2")
+	a := &BG1VersionedGroupId{
+		GroupIdPrefix:    "test",
+		Version:          *version,
+		BlueGreenVersion: *bgVersion,
+		Stage:            "a",
+		Updated:          time.Unix(1234567890, 0),
+	}
+	b := &BG1VersionedGroupId{ // distinct pointer, same content
+		GroupIdPrefix:    "test",
+		Version:          *version,
+		BlueGreenVersion: *bgVersion,
+		Stage:            "a",
+		Updated:          time.Unix(1234567890, 0),
+	}
+	other := &BG1VersionedGroupId{
+		GroupIdPrefix:    "test",
+		Version:          *version,
+		BlueGreenVersion: *bgVersion,
+		Stage:            "M",
+		Updated:          time.Unix(1234567890, 0),
+	}
+
+	assert.True(t, a.Equals(b))
+	assert.False(t, a.Equals(other))
 }


### PR DESCRIPTION
## Problem

The offset corrector compares `GroupId` values by interface identity. `GroupId` implementations are pointers, so two ids with identical content never compare equal. Two sites are affected:

- `offsetsIndexer.exists()` — the "group already exists, skip correction" check never matches, so the corrector runs on **every consumer initialization** of every service, not only for brand-new groups.
- `findPreviousStateOffset()` — the current group is never excluded from its own ancestor list.

For a plain (non-blue-green) group the inheritance strategies then resolve nothing, and the corrector falls into the install path, whose default is `Rewind(5m)`: the group's **committed offsets are force-rewritten** to the first record newer than five minutes. Records between the previously committed offset and that point are silently skipped, and because the rewrite is a committed offset, group lag reads 0 immediately — no WARN/ERROR is logged.

Observed on my env: on scale-up from 0 replicas, a group's partition was force-advanced 23081 → 23141 — 60 records permanently skipped with lag reading 0.

## Fix

- Key the group index by the canonical `GroupId.String()` instead of interface identity, fixing both comparison sites.
- An existing group's committed offsets are never altered on (re)initialization. If the topic has partitions the group has no committed offset for (e.g. partitions added after the group last committed), offsets are installed **for those partitions only**, using the configured setup strategy.
- Ignore Kafka's negative "no committed offset" sentinel (`OffsetFetch` reports `-1`) when indexing groups, so uncommitted partitions are not mistaken for committed ones.
- `install()` now errors when the adapter response omits a requested partition, instead of silently committing offset `0` from a missing map entry.
- Filter indexed offsets to the consumer's topic, so prefix-matched groups whose offsets belong to other topics no longer influence inheritance.
- Document the `NativeAdminAdapter` contract (complete per-partition responses; `nil` — not `0` — for "no record at/after timestamp"; omit uncommitted partitions) and the `Poll`/`ReadMessage` no-redelivery contract.

## Tests

Unit tests cover: identity-independent group lookup, ancestor self-exclusion, skip-on-existing-group (including with unmigrated BG1 leftovers present), partial install for new partitions only, missing-partition and missing-fallback errors, and the `-1` sentinel filter.

A cross-library integration test against a real broker (in qubership-core-lib-go-maas-bg-segmentio, PR to follow) verifies that an existing group survives consumer reinitialization with committed offsets untouched — even with unconsumed records older than the rewind window — and that partition expansion installs offsets for the new partitions only.

## Release note

The companion adapter fix in qubership-core-lib-go-maas-bg-segmentio (multi-partition `ListOffsets` queries) must not be released before or without this fix: against an unfixed corrector it widens the restart rewind from one random partition to every partition.